### PR TITLE
Update health-controller.ts

### DIFF
--- a/src/controller/health-controller.ts
+++ b/src/controller/health-controller.ts
@@ -1,5 +1,9 @@
 import express, { Request } from "express";
 import { IController } from "./interface/IController";
+import { Core } from "nodets-ms-core";
+// import storageService from "../service/storage-service";
+import path from "path";
+import fs from "fs";
 
 class HealthController implements IController {
     public path = '/health';
@@ -11,12 +15,48 @@ class HealthController implements IController {
 
     public intializeRoutes() {
         this.router.get(`${this.path}/ping`, this.getping);
+        this.router.get(`${this.path}/test-upload-zip-stream`, this.testUploadZipStream)
+        this.router.get(`${this.path}/test-redirect`, this.testRedirect)
+        this.router.get(`${this.path}/test-local-file`, this.testLocalFile)
     }
 
     public getping = async (request: Request, response: express.Response) => {
         // return loaded posts
         response.status(200).send("I'm healthy !!");
     }
+
+    testUploadZipStream = async (request: Request, response: express.Response) => {
+        // File Url is https://tdeisamplestorage.blob.core.windows.net/osw/test_upload/seattle.zip
+        const storageClient = Core.getStorageClient();
+        const containerName = "osw";
+        const blobName = "test_upload/seattle.zip";
+        const theFile = await storageClient?.getFile(containerName, blobName);
+        const fileStream = await theFile?.getStream()
+        // Respond with the file stream
+        response.setHeader('Content-Type', 'application/zip');
+        response.setHeader('Content-Disposition', `attachment; filename=seattle.zip`);
+        // response.send(fileStream)
+        // stream the content from fileStream to response
+        fileStream?.pipe(response);
+        
+    }
+
+    testRedirect = async (request: Request, response: express.Response) => {
+        // Redirect the response to a different url
+        response.redirect(301,'https://tdeisamplestorage.blob.core.windows.net/osw/test_upload/seattle.zip');
+    }
+
+    testLocalFile = async (request: Request, response: express.Response) => {
+        // get the path to osw-output folder
+        const filePath = path.resolve(__dirname, '../../../osw-output', 'seattle.zip');
+        // Respond with the file stream
+        // response.setHeader('Content-Type', 'application/zip');
+        // response.setHeader('Content-Disposition', `attachment; filename=seattle.zip`);
+        // const stream = fs.createReadStream(filePath);
+        // stream.pipe(response);
+        response.sendFile(filePath);
+    }
+
 }
 
 const healthController = new HealthController();


### PR DESCRIPTION
Updated health controller for testing
- This feature is an experiment to understand various expected times for downloading a data set
- There are three new paths added with this PR

1. `/health/test-upload-zip-stream` -> Gets the zip stream from the Azure storage and streams the content
2. `/health/test-redirect` -> redirects to the actual blob URL so that the streaming is taken care by Azure service itself
3. `/health/test-local-file` -> streams the local zipped file which is mounted with Azure file-share 

The intent of this experiment is to figure out various options available for consistency of download.
Post this deployment, we will do multiple downloads of the file and figure out the average time and consistency for each approach

This issue is related to both #935 and #972 tasks
https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/935
https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/972
