### PR TITLE
Download with SAS URL implemented

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "lodash": "4.17.21",
     "multer": "1.4.5-lts.1",
     "node-fetch": "^2.6.7",
-    "nodets-ms-core": "^0.0.12",
+    "nodets-ms-core": "^0.0.13",
     "pg": "^8.8.0",
     "reflect-metadata": "^0.1.13",
     "supertest": "^6.3.3"

--- a/src/controller/flex-controller.ts
+++ b/src/controller/flex-controller.ts
@@ -88,34 +88,18 @@ class FlexController implements IController {
     getFlexById = async (request: Request, response: express.Response, next: NextFunction) => {
 
         try {
-            const fileEntities: FileEntity[] = await flexService.getFlexStreamById(request.params.id);
-
-            const zipFileName = 'flex.zip';
-
-            // // Create a new zip archive
-            const archive = archiver('zip', { zlib: { level: 9 } });
-            response.setHeader('Content-Type', 'application/zip');
-            response.setHeader('Content-Disposition', `attachment; filename=${zipFileName}`);
-            archive.pipe(response);
-
-            // // Add files to the zip archive
-            for (const filee of fileEntities) {
-                archive.append(await filee.getStream(), { name: filee.fileName, store: true });
-
-            }
-
-            // // Finalize the archive and close the zip stream
-            archive.finalize();
+            const sasUrl = await flexService.getFlexDownloadUrl(request.params.id);
+            response.redirect(sasUrl);
 
         } catch (error: any) {
-            console.error('Error while getting the file stream');
+            console.error('Error while getting the file download URL');
             console.error(error);
             if (error instanceof HttpException) {
                 response.status(error.status).send(error.message);
                 return next(error);
             }
-            response.status(500).send("Error while getting the file stream");
-            next(new HttpException(500, "Error while getting the file stream"));
+            response.status(500).send("Error while getting download URL");
+            next(new HttpException(500, "Error while getting download URL for dataset"));
         }
     }
 

--- a/src/database/entity/dataset-entity.ts
+++ b/src/database/entity/dataset-entity.ts
@@ -51,6 +51,8 @@ export class DatasetEntity extends BaseDto {
     latest_dataset_url!: string;
     @Prop()
     latest_osm_url!: string;
+    @Prop()
+    dataset_download_url!: string;
 
     constructor(init?: Partial<DatasetEntity>) {
         super();

--- a/src/service/flex-service.ts
+++ b/src/service/flex-service.ts
@@ -314,6 +314,26 @@ class FlexService implements IFlexService {
         }
         return ''
     }
+
+    async getFlexDownloadUrl(tdei_dataset_id: string): Promise<string> {
+        let dataset = await this.tdeiCoreServiceInstance.getDatasetDetailsById(tdei_dataset_id);
+        if (dataset.data_type && dataset.data_type !== TDEIDataType.flex)
+            throw new InputException(`${tdei_dataset_id} is not a flex dataset.`);
+
+        const storageClient = Core.getStorageClient();
+        if (storageClient == null) throw new Error("Storage not configured");
+        const download_url = dataset.dataset_download_url;
+        if (download_url == undefined || download_url == null || download_url == ""){
+            throw new InputException(`${tdei_dataset_id} is not archived yet.`);
+        }
+        let dlUrl = new URL(download_url);
+        let relative_path = dlUrl.pathname;
+        let container = relative_path.split('/')[1];
+        // let file_path = relative_path.split('/').
+        let file_path_in_container = relative_path.split('/').slice(2).join('/');
+        let sasUrl = storageClient.getSASUrl(container, file_path_in_container,12); // 12 hours expiry
+        return sasUrl;
+    }
 }
 
 const flexService: IFlexService = new FlexService(jobService, tdeiCoreService);

--- a/src/service/interface/flex-service-interface.ts
+++ b/src/service/interface/flex-service-interface.ts
@@ -17,6 +17,15 @@ export interface IFlexService {
     getFlexStreamById(id: string): Promise<FileEntity[]>;
 
     /**
+     * Retrieves the Flex Download(SAS) URL by its Dataset Id.
+     * @param id - The ID of the Dataset.
+     * @returns A promise that resolves to the download URL.
+     * @throws HttpException if the FlexStream is not found or if the request record is deleted.
+     * @throws Error if the storage is not configured.
+     */
+    getFlexDownloadUrl(id: string): Promise<string>;
+
+    /**
     * Processes the upload request and performs various validations and operations.
     * 
     * @param uploadRequestObject - The upload request object containing the necessary information.

--- a/test/common/mock-utils.ts
+++ b/test/common/mock-utils.ts
@@ -41,6 +41,9 @@ export function getMockStorageClient() {
         },
         getFileFromUrl: function (): Promise<FileEntity> {
             return Promise.resolve(getMockFileEntity());
+        },
+        getSASUrl: function (): Promise<string> {
+            return Promise.resolve(getMockSASUrl());
         }
     };
     return storageClientObj;
@@ -66,6 +69,10 @@ export function getMockTopic() {
     }
 
     return mockTopic;
+}
+
+export function getMockSASUrl(){
+    return "https://test.com";
 }
 
 export function mockAppContext() {

--- a/test/unit/flex.controller.test.ts
+++ b/test/unit/flex.controller.test.ts
@@ -1,7 +1,7 @@
 import { getMockReq, getMockRes } from "@jest-mock/express";
 import HttpException from "../../src/exceptions/http/http-base-exception";
 import { InputException } from "../../src/exceptions/http/http-exceptions";
-import { getMockFileEntity } from "../common/mock-utils";
+import { getMockFileEntity, getMockSASUrl } from "../common/mock-utils";
 import { DatasetDTO } from "../../src/model/dataset-dto";
 import tdeiCoreService from "../../src/service/tdei-core-service";
 import flexService from "../../src/service/flex-service";
@@ -61,14 +61,14 @@ describe("Flex Controller Test", () => {
     describe("Get Flex file by Id", () => {
 
         describe("Functional", () => {
-            test("When requested for valid tdei_dataset_id, Expect to return downloadable file stream", async () => {
+            test("When requested for valid tdei_dataset_id, Expect to return downloadable file SAS URL", async () => {
                 //Arrange
                 const req = getMockReq();
                 const { res, next } = getMockRes();
 
                 const getFlexByIdSpy = jest
-                    .spyOn(flexService, "getFlexStreamById")
-                    .mockResolvedValueOnce([getMockFileEntity()]);
+                    .spyOn(flexService, "getFlexDownloadUrl")
+                    .mockResolvedValueOnce(getMockSASUrl());
                 //Act
                 await flexController.getFlexById(req, res, next);
                 //Assert
@@ -81,7 +81,7 @@ describe("Flex Controller Test", () => {
                 const { res, next } = getMockRes();
 
                 jest
-                    .spyOn(flexService, "getFlexStreamById")
+                    .spyOn(flexService, "getFlexDownloadUrl")
                     .mockRejectedValueOnce(new HttpException(404, "Record not found"));
                 //Act
                 await flexController.getFlexById(req, res, next);
@@ -96,7 +96,7 @@ describe("Flex Controller Test", () => {
                 const { res, next } = getMockRes();
 
                 jest
-                    .spyOn(flexService, "getFlexStreamById")
+                    .spyOn(flexService, "getFlexDownloadUrl")
                     .mockRejectedValueOnce(new Error("Unexpected error"));
                 //Act
                 await flexController.getFlexById(req, res, next);


### PR DESCRIPTION
- Download with SAS URL implemented for Flex.
- This is linked to task 991
- Now, the flex download request is redirected to a SAS url with an expiry of 12 hours.