### PR TITLE
Feature include qm on demand

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -9,6 +9,7 @@ import dbClient from "./database/data-source";
 import HttpException from "./exceptions/http/http-base-exception";
 import { IOrchestratorService } from "./orchestrator/services/orchestrator-service";
 import orchestratorConfig_v2 from "./tdei-orchestrator-config_v2.json";
+// import orchestratorConfig_v2 from "./workflow_example.json";
 import workflows_v2_register from "./orchestrator_v2/index";
 import appContext from "./app-context";
 import { IOrchestratorService_v2, OrchestratorService_v2 } from "./orchestrator_v2/orchestrator-service-v2";

--- a/src/constants/app-constants.ts
+++ b/src/constants/app-constants.ts
@@ -14,4 +14,5 @@ export enum WorkflowName {
     "pathways_publish" = "pathways_publish",
     "pathways_validation_only" = "pathways_validation_only",
     "osw_spatial_join" = "osw_spatial_join",
+    "osw_quality_on_demand" = "osw_quality_metric_on_demand",
 }

--- a/src/controller/osw-controller.ts
+++ b/src/controller/osw-controller.ts
@@ -105,6 +105,8 @@ class OSWController implements IController {
         this.router.post(`${this.path}/dataset-bbox`, authenticate, this.processDatasetBboxRequest);
         this.router.post(`${this.path}/dataset-tag-road`, authenticate, this.processDatasetTagRoadRequest);
         this.router.post(`${this.path}/spatial-join`, authenticate, this.processSpatialQueryRequest);
+        // Route for quality metric request
+        this.router.post(`${this.path}/quality-metric/:tdei_dataset_id`,authenticate ,this.createQualityOnDemandRequest);
     }
 
 
@@ -230,66 +232,6 @@ class OSWController implements IController {
             }
             const redirectUrl = await oswService.getDownloadableOSWUrl(request.params.id, format, file_version);
             response.redirect(redirectUrl);
-            // const fileEntities: FileEntity[] = await oswService.getOswStreamById(request.params.id, format, file_version);
-
-            // const zipFileName = `${request.params.id}_${format}_${file_version}.zip`;
-
-            // // Create a new zip archive
-            // const zip = new AdmZip();
-
-            // //create folder if not exists localFilePath
-            // let directory_path = path.join(`${__dirname}//${randomUUID().toString()}`);
-            // if (!fs.existsSync(directory_path)) {
-            //     fs.mkdirSync(directory_path);
-            // }
-
-            // // Add files to the zip archive
-            // for (const filee of fileEntities) {
-            //     // Create a write stream for the local file
-            //     const localFilePath = path.join(directory_path, filee.fileName);
-
-            //     const writeStream = fs.createWriteStream(localFilePath);
-
-            //     // Get the file stream and pipe it to the write stream
-            //     const fileStream = await filee.getStream();
-            //     fileStream.pipe(writeStream);
-
-            //     // Wait for the write stream to finish
-            //     await new Promise((resolve, reject) => {
-            //         writeStream.on('finish', resolve);
-            //         writeStream.on('error', reject);
-            //     });
-
-            //     // Add the local file to the zip archive
-            //     zip.addLocalFile(localFilePath);
-
-            //     // Delete the local file
-            //     fs.unlinkSync(localFilePath);
-            // }
-            // fs.rmdirSync(directory_path);
-            // // Generate the zip file
-            // const zipFile = zip.toBuffer();
-
-            // // Set the headers and send the file
-            // response.setHeader('Content-Type', 'application/zip');
-            // response.setHeader('Content-Disposition', `attachment; filename=${zipFileName}`);
-            // response.send(zipFile);
-            // // const zipFileName = 'osw.zip';
-
-            // // // // Create a new zip archive
-            // // const archive = archiver('zip', { zlib: { level: 9 } });
-            // // response.setHeader('Content-Type', 'application/zip');
-            // // response.setHeader('Content-Disposition', `attachment; filename=${zipFileName}`);
-            // // archive.pipe(response);
-
-            // // // // Add files to the zip archive
-            // // for (const filee of fileEntities) {
-            // //     // Read into a stream
-            // //     archive.append(await filee.getStream(), { name: filee.fileName, store: true });
-            // // }
-
-            // // // // Finalize the archive and close the zip stream
-            // // archive.finalize();
 
         } catch (error: any) {
             console.error('Error while getting the file stream');
@@ -399,31 +341,6 @@ class OSWController implements IController {
         }
     }
 
-    // /**
-    // * Flatterning the tdei record 
-    // * @param request 
-    // * @param response 
-    // * @param next 
-    // * @returns 
-    // */
-    // processFlatteningRequest = async (request: Request, response: express.Response, next: NextFunction) => {
-    //     try {
-    //         let tdei_dataset_id = request.params["tdei_dataset_id"];
-    //         let override = Boolean(request.query.override as string) ? true : false;
-
-    //         let job_id = await oswService.processDatasetFlatteningRequest(request.body.user_id, tdei_dataset_id, override);
-    //         response.setHeader('Location', `/api/v1/job?job_id=${job_id}`);
-    //         return response.status(202).send(job_id);
-    //     } catch (error) {
-    //         console.error("Error while processing the flattening request", error);
-    //         if (error instanceof HttpException) {
-    //             response.status(error.status).send(error.message);
-    //             return next(error);
-    //         }
-    //         response.status(500).send("Error while processing the flattening request");
-    //         next(new HttpException(500, "Error while processing the flattening request"));
-    //     }
-    // }
 
     /**
      * Function to create record in the database and upload the gtfs-osw files
@@ -557,6 +474,30 @@ class OSWController implements IController {
             }
             response.status(500).send("Error while processing the format request");
             next(new HttpException(500, "Error while processing the format request"));
+        }
+    }
+
+    createQualityOnDemandRequest = async (request: Request, response: express.Response, next: NextFunction) => {
+        try {
+            let tdei_dataset_id = request.params["tdei_dataset_id"];
+            let algorithms = request.body.algorithms;
+            let persist = request.body.persist;
+            if (tdei_dataset_id == undefined || algorithms == undefined || persist == undefined) {
+                response.status(400).send('Please add tdei_dataset_id, algorithms, persist in payload')
+                return next()
+            }
+            let job_id = await oswService.calculateQualityMetric(tdei_dataset_id, algorithms, persist,request.body.user_id);
+            response.setHeader('Location', `/api/v1/job?job_id=${job_id}`);
+            return response.status(202).send(job_id);
+
+        } catch (error) {
+            console.error("Error while processing the quality metric request", error);
+            if (error instanceof HttpException) {
+                response.status(error.status).send(error.message);
+                return next(error);
+            }
+            response.status(500).send("Error while processing the quality metric request");
+            next(new HttpException(500, "Error while processing the quality metric request"));
         }
     }
 }

--- a/src/controller/osw-controller.ts
+++ b/src/controller/osw-controller.ts
@@ -482,9 +482,11 @@ class OSWController implements IController {
             let tdei_dataset_id = request.params["tdei_dataset_id"];
             let algorithms = request.body.algorithms;
             let persist = request.body.persist;
+            if (tdei_dataset_id == undefined) {
+                throw new InputException("Missing tdei_dataset_id input")
+            }
             if (tdei_dataset_id == undefined || algorithms == undefined || persist == undefined) {
-                response.status(400).send('Please add tdei_dataset_id, algorithms, persist in payload')
-                return next()
+                throw new InputException("Please add tdei_dataset_id, algorithms, persist in payload")
             }
             let job_id = await oswService.calculateQualityMetric(tdei_dataset_id, algorithms, persist,request.body.user_id);
             response.setHeader('Location', `/api/v1/job?job_id=${job_id}`);
@@ -496,8 +498,8 @@ class OSWController implements IController {
                 response.status(error.status).send(error.message);
                 return next(error);
             }
-            response.status(500).send("Error while processing the quality metric request");
-            next(new HttpException(500, "Error while processing the quality metric request"));
+            response.status(500).send("Error while processing the quality metric");
+            next(new HttpException(500, "Error while processing the quality metric"));
         }
     }
 }

--- a/src/model/jobs-get-query-params.ts
+++ b/src/model/jobs-get-query-params.ts
@@ -27,7 +27,8 @@ export enum JobType {
     "Dataset-Publish" = "Dataset-Publish",
     "Dataset-Validate" = "Dataset-Validate",
     "Dataset-Flatten" = "Dataset-Flatten",
-    "Dataset-Queries" = "Dataset-Queries"
+    "Dataset-Queries" = "Dataset-Queries",
+    "Quality-Metric" = "Quality-Metric"
 }
 export class JobsQueryParams {
     @IsOptional()

--- a/src/orchestrator_v2/orchestrator_v2.md
+++ b/src/orchestrator_v2/orchestrator_v2.md
@@ -147,6 +147,12 @@ Here’s an example configuration for a new workflow:
 4. **Specify exception handling tasks** to manage failures.
 5. **Define subscriptions** for listening to responses (`task1-response`).
 
+
+### Testing and debugging new or existing workflows
+There may be a case where you want to update the existing workflow or test with a new workflow. In that case, use `workflow_example.json` file for testing.
+- Simply write the updated workflows in the json file
+- In `app.ts` replace `import orchestratorConfig_v2 from "./tdei-orchestrator-config_v2.json";` line with the new file location.
+
 ### Writing Functions for Specific Logic
 
 For tasks that require specific or custom logic, functions should be defined in `task-functions.ts`. Here are the conventions to follow:

--- a/src/service/interface/osw-service-interface.ts
+++ b/src/service/interface/osw-service-interface.ts
@@ -65,6 +65,19 @@ export interface IOswService {
      */
     calculateConfidence(tdei_dataset_id: string, sub_regions_file: Express.Multer.File | undefined, user_id: string): Promise<string>;
 
+
+    
+    /**
+     * Calculates the quality metric for a given TDEI dataset.
+     * 
+     * @param tdei_dataset_id - The ID of the TDEI dataset.
+     * @param algorithms - The algorithms to use for calculating the quality metric.
+     * @param persist - The persist flag.
+     * @returns A Promise that resolves to the ID of the created job.
+     * @throws If there is an error calculating the quality metric.
+     */
+    calculateQualityMetric(tdei_dataset_id:string, algorithms:string[],persist:any, user_id:string):Promise<string>;
+
     /**
      * Retrieves the OswStream by its ID.
      * @param id - The ID of the OswStream.

--- a/src/tdei-orchestrator-config_v2.json
+++ b/src/tdei-orchestrator-config_v2.json
@@ -1694,6 +1694,84 @@
                     "function": "update_table"
                 }
             ]
+        },
+        {
+            "name": "osw_quality_metric_on_demand",
+            "description": "Calculate the quality metric of dataset and persist optionally",
+            "workflow_input": {
+                "job_id": "<%=job_id%>",
+                "user_id": "<%=user_id%>",
+                "file_url": "<%=file_url%>",
+                "algorithms": "<%=algorithms%>",
+                "persist": "<%=persist%>"
+            },
+            "tasks": [
+                {
+                    "name": "osw_quality_metric_on_demand",
+                    "task_reference_name": "osw_quality_metric_on_demand",
+                    "description": "Calculating the Quality metric score of the dataset",
+                    "type": "Event",
+                    "topic": "osw-quality-request",
+                    "input_params": {
+                        "jobId": "<%=JSON.stringify(workflow_input.job_id)%>",
+                        "data_file": "<%=workflow_input.file_url%>",
+                        "algorithms": "<%=workflow_input.algorithms%>"
+                    },
+                    "output_params": {
+                        "success": "<%=data.success%>",
+                        "message": "<%=data.message%>",
+                        "dataset_url": "<%= data.dataset_url %>",
+                        "qm_dataset_url": "<%=data.qm_dataset_url%>"
+                    }
+                },
+                {
+                    "name": "update_quality_metric_job_db",
+                    "task_reference_name": "update_quality_metric_job_db",
+                    "description": "Updating the quality metric score to the job details",
+                    "type": "Utility",
+                    "input_params": {
+                        "table": "content.job",
+                        "where": {
+                            "job_id": "<%=workflow_input.job_id%>"
+                        },
+                        "data": {
+                            "response_props": {
+                                "dataset_url": "<%=tasks.osw_quality_metric_on_demand.output.dataset_url%>",
+                                "qm_dataset_url": "<%=tasks.osw_quality_metric_on_demand.output.qm_dataset_url%>"
+                            },
+                            "updated_at": "CURRENT_TIMESTAMP",
+                            "status": "COMPLETED"
+                        }
+                    },
+                    "output_params": {
+                        "success": "<%=success%>",
+                        "message": "<%=message%>"
+                    },
+                    "function": "update_table"
+                }
+            ],
+            "exception_task": [
+                {
+                    "name": "job_failure_db",
+                    "task_reference_name": "job_failure_db",
+                    "description": "Updating the job details on failure",
+                    "type": "Exception",
+                    "input_params": {
+                        "table": "content.job",
+                        "where": {
+                            "job_id": "<%=workflow_input.job_id%>"
+                        },
+                        "data": {
+                            "status": "FAILED"
+                        }
+                    },
+                    "output_params": {
+                        "success": "<%=success%>",
+                        "message": "<%=message%>"
+                    },
+                    "function": "update_table"
+                }
+            ]
         }
     ],
     "subscriptions": [
@@ -1735,6 +1813,11 @@
         {
             "description": "Subscription for dataset zipping completion",
             "topic": "dataset-zip-response",
+            "subscription": "res-handler"
+        },
+        {
+            "description": "Subscription for osw quality metrics completion",
+            "topic": "osw-quality-response",
             "subscription": "res-handler"
         }
     ]

--- a/src/workflow_example.json
+++ b/src/workflow_example.json
@@ -1,0 +1,89 @@
+{
+    "workflows": [
+{
+    "name": "osw_quality_metric_on_demand",
+    "description": "Calculate the quality metric of dataset and persist optionally",
+    "workflow_input": {
+        "job_id": "<%=job_id%>",
+        "user_id": "<%=user_id%>",
+        "file_url": "<%=file_url%>",
+        "algorithms": "<%=algorithms%>",
+        "persist": "<%=persist%>"
+    },
+    "tasks": [
+        {
+            "name": "osw_quality_metric_on_demand",
+            "task_reference_name": "osw_quality_metric_on_demand",
+            "description": "Calculating the Quality metric score of the dataset",
+            "type": "Event",
+            "topic": "osw-quality-request",
+            "input_params": {
+                "jobId": "<%=JSON.stringify(workflow_input.job_id)%>",
+                "data_file": "<%=workflow_input.file_url%>",
+                "algorithms": "<%=workflow_input.algorithms%>"
+            },
+            "output_params": {
+                "success": "<%=data.success%>",
+                "message": "<%=data.message%>",
+                "dataset_url": "<%= data.dataset_url %>",
+                "qm_dataset_url": "<%=data.qm_dataset_url%>"
+            }
+        },
+        {
+            "name": "update_quality_metric_job_db",
+            "task_reference_name": "update_quality_metric_job_db",
+            "description": "Updating the quality metric score to the job details",
+            "type": "Utility",
+            "input_params": {
+                "table": "content.job",
+                "where": {
+                    "job_id": "<%=workflow_input.job_id%>"
+                },
+                "data": {
+                    "response_props": {
+                        "dataset_url": "<%=tasks.osw_quality_metric_on_demand.output.dataset_url%>",
+                        "qm_dataset_url": "<%=tasks.osw_quality_metric_on_demand.output.qm_dataset_url%>"
+                    },
+                    "updated_at": "CURRENT_TIMESTAMP",
+                    "status": "COMPLETED"
+                }
+            },
+            "output_params": {
+                "success": "<%=success%>",
+                "message": "<%=message%>"
+            },
+            "function": "update_table"
+        }
+    ],
+    "exception_task": [
+        {
+            "name": "job_failure_db",
+            "task_reference_name": "job_failure_db",
+            "description": "Updating the job details on failure",
+            "type": "Exception",
+            "input_params": {
+                "table": "content.job",
+                "where": {
+                    "job_id": "<%=workflow_input.job_id%>"
+                },
+                "data": {
+                    "status": "FAILED"
+                }
+            },
+            "output_params": {
+                "success": "<%=success%>",
+                "message": "<%=message%>"
+            },
+            "function": "update_table"
+        }
+    ]
+}
+],
+"subscriptions": [
+    {
+        "description": "Subscription for osw quality metrics completion",
+        "topic": "osw-quality-response",
+        "subscription": "res-handler"
+    }
+]
+}


### PR DESCRIPTION

## Quality metric for OSW Dataset
- Added implementation for including quality metric on demand
- This PR covers only the non-persistent part of the calculation.
- Persistence of the calculation is not done on this.
- This is related to [Task 993](https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/993): Feature 5.1 – TDEICore: Element Quality Metric: Write library
- Only the flow is tested as of now. 
- Right now there is no provisioning on the UI to download the dataset. Will be separate ticket
- Unit tests updated and tested for the new route as well

Added API Path:
- `/quality-metric/:tdei_dataset_id` with POST and with the following body
```json
{
"algorithms":["fixed","random"],
"persist":[{"fixed":"all"},{"random":"nodes"}]
}
``` 
Documentation for the payload will be updated soon.