### PR TITLE
Add workflow for incline service

### DIFF
--- a/src/constants/app-constants.ts
+++ b/src/constants/app-constants.ts
@@ -17,4 +17,5 @@ export enum WorkflowName {
     "osw_quality_on_demand" = "osw_quality_metric_on_demand",
     "build_dataset_download" = "build_dataset_download",
     "build_osw_osm_dataset_download" = "build_osw_osm_dataset_download",
+    "osw_dataset_incline_tag" = "osw_dataset_incline_tag",
 }

--- a/src/controller/osw-controller.ts
+++ b/src/controller/osw-controller.ts
@@ -12,7 +12,7 @@ import { IUploadRequest } from "../service/interface/upload-request-interface";
 import { metajsonValidator } from "../middleware/metadata-json-validation-middleware";
 import { authorize } from "../middleware/authorize-middleware";
 import { authenticate } from "../middleware/authenticate-middleware";
-import { BboxServiceRequest, TagRoadServiceRequest } from "../model/backend-request-interface";
+import { BboxServiceRequest, TagRoadServiceRequest, InclinationServiceRequest } from "../model/backend-request-interface";
 import tdeiCoreService from "../service/tdei-core-service";
 import { Utility } from "../utility/utility";
 import Ajv, { ErrorObject } from "ajv";
@@ -144,6 +144,7 @@ class OSWController implements IController {
         // Route for quality metric request
         this.router.post(`${this.path}/quality-metric/:tdei_dataset_id`, qualityUpload.single('file'),authenticate, this.createQualityOnDemandRequest);
         this.router.post(`${this.path}/quality-metric/tag/:tdei_dataset_id`, tagQuality.single('file'), authenticate, this.tagQualityMetric);
+        this.router.post(`${this.path}/dataset-add-inclination/`, authenticate, this.createInclineRequest);
     }
 
 
@@ -563,6 +564,61 @@ class OSWController implements IController {
             }
             response.status(500).send("Error while processing the quality metric");
             next(new HttpException(500, "Error while processing the quality metric"));
+        }
+    }
+
+
+    /**
+     * Request to calculate the inclination for the given dataset
+     * @param request 
+     * @param response 
+     * @param next 
+     * @returns 
+     */
+    createInclineRequest = async (request: Request, response: express.Response, next: NextFunction) => {
+        try {
+
+            const requestService = JSON.parse(JSON.stringify(request.query));
+            if (!requestService) {
+                return next(new InputException('request body is empty', response));
+            }
+
+            if (requestService.dataset_id == undefined) {
+                return next(new InputException('required input is empty', response));
+            }
+
+            let apiKey = request.headers['x-api-key'];
+            //Reject authorization for API key users
+            if (apiKey && apiKey !== '') {
+                return next(new UnAuthenticated());
+            }
+
+            //Authorize
+            let osw = await tdeiCoreService.getDatasetDetailsById(requestService.dataset_id);
+            var authorized = await Utility.authorizeRoles(request.body.user_id, osw.tdei_project_group_id, ["tdei_admin", "poc", "osw_data_generator"]);
+            if (!authorized) {
+                return next(new ForbiddenAccess());
+            }
+
+            let backendRequest: InclinationServiceRequest = {
+                user_id: request.body.user_id,
+                service: "add_inclination",
+                parameters: {
+                    dataset_id: requestService.dataset_id
+                }
+            }
+
+            let job_id = await oswService.calculateInclanation(backendRequest);
+            response.setHeader('Location', `/api/v1/job?job_id=${job_id}`);
+            return response.status(202).send(job_id);
+        } catch (error) {
+            console.error("Error while processing the incline dataset request", error);
+            if (error instanceof HttpException) {
+                response.status(error.status).send(error.message);
+                return next(error);
+            }
+            response.status(500).send("Error while processing the incline dataset request");
+            next(new HttpException(500, "Error while processing the incline dataset request"));
         }
     }
 }

--- a/src/controller/osw-controller.ts
+++ b/src/controller/osw-controller.ts
@@ -603,7 +603,7 @@ class OSWController implements IController {
                 }
             }
 
-            let job_id = await oswService.calculateInclanation(backendRequest);
+            let job_id = await oswService.calculateInclination(backendRequest);
             response.setHeader('Location', `/api/v1/job?job_id=${job_id}`);
             return response.status(202).send(job_id);
         } catch (error) {

--- a/src/model/backend-request-interface.ts
+++ b/src/model/backend-request-interface.ts
@@ -16,3 +16,12 @@ export interface TagRoadServiceRequest {
         target_dataset_id: string;
     };
 }
+
+
+export interface InclinationServiceRequest {
+    user_id: string;
+    service: string;
+    parameters: {
+        dataset_id: string;
+    };
+}

--- a/src/model/jobs-get-query-params.ts
+++ b/src/model/jobs-get-query-params.ts
@@ -31,7 +31,8 @@ export enum JobType {
     "Dataset-Queries" = "Dataset-Queries",
     "Quality-Metric" = "Quality-Metric",
     "Edit-Metadata" = "Edit-Metadata",
-    "Clone-Dataset" = "Clone-Dataset"
+    "Clone-Dataset" = "Clone-Dataset",
+    "Dataset-Incline-Tag" = "Dataset-Incline-Tag"
 }
 export class JobsQueryParams {
     @IsOptional()

--- a/src/service/interface/osw-service-interface.ts
+++ b/src/service/interface/osw-service-interface.ts
@@ -151,5 +151,5 @@ export interface IOswService {
      * @returns A Promise that resolves to a string representing the job ID.
      * @throws Throws an error if an error occurs during processing.
      */
-    calculateInclanation(backendRequest: InclinationServiceRequest): Promise<string>;
+    calculateInclination(backendRequest: InclinationServiceRequest): Promise<string>;
 }

--- a/src/service/interface/osw-service-interface.ts
+++ b/src/service/interface/osw-service-interface.ts
@@ -1,6 +1,6 @@
 import { FileEntity } from "nodets-ms-core/lib/core/storage";
 import { IUploadRequest } from "./upload-request-interface";
-import { BboxServiceRequest, TagRoadServiceRequest } from "../../model/backend-request-interface";
+import { BboxServiceRequest, TagRoadServiceRequest, InclinationServiceRequest } from "../../model/backend-request-interface";
 import { IJobService } from "./job-service-interface";
 import { ITdeiCoreService } from "./tdei-core-service-interface";
 import { SpatialJoinRequest } from "../../model/request-interfaces";
@@ -142,4 +142,14 @@ export interface IOswService {
      * @throws Throws an error if an error occurs during processing.
      */
     processValidationOnlyRequest(user_id: string, datasetFile: any): Promise<string>;
+
+
+    /**
+     * Calculates inclination for a given TDEI dataset.
+     * 
+     * @param backendRequest The backend request to process.
+     * @returns A Promise that resolves to a string representing the job ID.
+     * @throws Throws an error if an error occurs during processing.
+     */
+    calculateInclanation(backendRequest: InclinationServiceRequest): Promise<string>;
 }

--- a/src/service/osw-service.ts
+++ b/src/service/osw-service.ts
@@ -1055,7 +1055,7 @@ class OswService implements IOswService {
     * @returns A Promise that resolves to a string representing the job ID.
     * @throws Throws an error if an error occurs during processing.
     */
-    async calculateInclanation(backendRequest: InclinationServiceRequest): Promise<string> {
+    async calculateInclination(backendRequest: InclinationServiceRequest): Promise<string> {
         try {
 
             //Only if backendRequest.parameters.target_dataset_id id in pre-release status

--- a/src/service/osw-service.ts
+++ b/src/service/osw-service.ts
@@ -1069,9 +1069,8 @@ class OswService implements IOswService {
                 status: JobStatus["IN-PROGRESS"],
                 message: 'Job started',
                 request_input: {
-                    service: backendRequest.service,
                     user_id: backendRequest.user_id,
-                    parameters: backendRequest.parameters
+                    dataset_id: backendRequest.parameters.dataset_id
                 },
                 tdei_project_group_id: '',
                 user_id: backendRequest.user_id,
@@ -1082,12 +1081,12 @@ class OswService implements IOswService {
             let workflow_start = WorkflowName.osw_dataset_incline_tag;
             let workflow_input = {
                 job_id: job_id.toString(),
-                service: backendRequest.service,
                 user_id: backendRequest.user_id,
-                parameters: backendRequest.parameters,
-                tdei_dataset_id: backendRequest.parameters.dataset_id,
                 dataset_url: dataset.latest_dataset_url,
-                tdei_project_group_id: dataset.tdei_project_group_id
+                metadata_url: dataset.metadata_url,
+                changeset_url: dataset.changeset_url,
+                tdei_project_group_id: dataset.tdei_project_group_id,
+                tdei_dataset_id: dataset.tdei_dataset_id
             };
             //Trigger the workflow
             await appContext.orchestratorService_v2_Instance!.startWorkflow(job_id.toString(), workflow_start, workflow_input, backendRequest.user_id);

--- a/src/service/osw-service.ts
+++ b/src/service/osw-service.ts
@@ -10,7 +10,7 @@ import { Readable } from "stream";
 import storageService from "./storage-service";
 import appContext from "../app-context";
 import { IOswService } from "./interface/osw-service-interface";
-import { BboxServiceRequest, TagRoadServiceRequest } from "../model/backend-request-interface";
+import { BboxServiceRequest, InclinationServiceRequest, TagRoadServiceRequest } from "../model/backend-request-interface";
 import jobService from "./job-service";
 import { IJobService } from "./interface/job-service-interface";
 import { CreateJobDTO } from "../model/job-dto";
@@ -1046,6 +1046,55 @@ class OswService implements IOswService {
         } catch (error) {
             console.log('Error calculating quality metric ', error);
             return Promise.reject(error);
+        }
+    }
+
+    /**
+    * Processes a inclination request by uploading a file, creating a job, triggering a workflow, and returning the job ID.
+    * @param backendRequest The backend request to process.
+    * @returns A Promise that resolves to a string representing the job ID.
+    * @throws Throws an error if an error occurs during processing.
+    */
+    async calculateInclanation(backendRequest: InclinationServiceRequest): Promise<string> {
+        try {
+
+            //Only if backendRequest.parameters.target_dataset_id id in pre-release status
+            const dataset = await this.tdeiCoreServiceInstance.getDatasetDetailsById(backendRequest.parameters.dataset_id);
+            if (dataset.status !== RecordStatus["Pre-Release"])
+                throw new InputException(`Dataset ${backendRequest.parameters.dataset_id} is not in Pre-Release state. Dataset incline tagging request allowed in Pre-Release state only.`);
+
+            let job = CreateJobDTO.from({
+                data_type: TDEIDataType.osw,
+                job_type: JobType["Dataset-Incline-Tag"],
+                status: JobStatus["IN-PROGRESS"],
+                message: 'Job started',
+                request_input: {
+                    service: backendRequest.service,
+                    user_id: backendRequest.user_id,
+                    parameters: backendRequest.parameters
+                },
+                tdei_project_group_id: '',
+                user_id: backendRequest.user_id,
+            });
+
+            const job_id = await this.jobServiceInstance.createJob(job);
+            
+            let workflow_start = WorkflowName.osw_dataset_incline_tag;
+            let workflow_input = {
+                job_id: job_id.toString(),
+                service: backendRequest.service,
+                user_id: backendRequest.user_id,
+                parameters: backendRequest.parameters,
+                tdei_dataset_id: backendRequest.parameters.dataset_id,
+                dataset_url: dataset.latest_dataset_url,
+                tdei_project_group_id: dataset.tdei_project_group_id
+            };
+            //Trigger the workflow
+            await appContext.orchestratorService_v2_Instance!.startWorkflow(job_id.toString(), workflow_start, workflow_input, backendRequest.user_id);
+
+            return Promise.resolve(job_id.toString());
+        } catch (error) {
+            throw error;
         }
     }
 }

--- a/src/tdei-orchestrator-config_v2.json
+++ b/src/tdei-orchestrator-config_v2.json
@@ -2070,13 +2070,13 @@
             "name": "osw_dataset_incline_tag",
             "description": "Update the dataset with incline tags",
             "workflow_input": {
-                "service": "<%=service %>",
-                "user_id": "<%=user_id%>",
-                "parameters": "<%= JSON.stringify(parameters) %>",
-                "tdei_project_group_id": "<%=tdei_project_group_id%>",
-                "tdei_dataset_id": "<%=tdei_dataset_id%>",
                 "job_id": "<%=job_id%>",
-                "dataset_url": "<%=dataset_url%>"
+                "user_id": "<%=user_id%>",
+                "dataset_url": "<%=dataset_url%>",
+                "metadata_url": "<%=metadata_url%>",
+                "changeset_url": "<%=changeset_url%>",
+                "tdei_dataset_id":"<%=tdei_dataset_id%>",
+                "tdei_project_group_id":"<%=tdei_project_group_id%>"
             },
             "tasks": [
                 {
@@ -2159,7 +2159,7 @@
                     "description": "Getting the blob folder path for zip upload",
                     "type": "Utility",
                     "input_params": {
-                        "blobUrl": "<%=workflow_input.dataset_url%>",
+                        "blobUrl": "<%=tasks.osw_dataset_incline_tag.output.file_upload_path%>",
                         "identifier": "<%=workflow_input.tdei_dataset_id%>"
                     },
                     "output_params": {

--- a/src/tdei-orchestrator-config_v2.json
+++ b/src/tdei-orchestrator-config_v2.json
@@ -2065,6 +2065,227 @@
                     "function": "update_table"
                 }
             ]
+        },
+        {
+            "name": "osw_dataset_incline_tag",
+            "description": "Update the dataset with incline tags",
+            "workflow_input": {
+                "service": "<%=service %>",
+                "user_id": "<%=user_id%>",
+                "parameters": "<%= JSON.stringify(parameters) %>",
+                "tdei_project_group_id": "<%=tdei_project_group_id%>",
+                "tdei_dataset_id": "<%=tdei_dataset_id%>",
+                "job_id": "<%=job_id%>",
+                "dataset_url": "<%=dataset_url%>"
+            },
+            "tasks": [
+                {
+                    "name": "osw_dataset_incline_tag",
+                    "task_reference_name": "osw_dataset_incline_tag",
+                    "description": "Updating the dataset with incline tags",
+                    "type": "Event",
+                    "topic": "osw-incline-request",
+                    "input_params": {
+                        "jobId": "<%=JSON.stringify(workflow_input.job_id)%>",
+                        "user_id": "<%=workflow_input.user_id%>",
+                        "dataset_url": "<%=workflow_input.dataset_url%>"
+                    },
+                    "output_params": {
+                        "success": "<%=data.success%>",
+                        "message": "<%=data.message%>",
+                        "file_upload_path": "<%=data.file_upload_path%>"
+                    }
+                },
+                {
+                    "name": "update_osw_incline_tag_url_db",
+                    "task_reference_name": "update_osw_incline_tag_url_db",
+                    "description": "Updating the updated osw dataset url",
+                    "type": "Utility",
+                    "input_params": {
+                        "table": "content.dataset",
+                        "where": {
+                            "tdei_dataset_id": "<%=workflow_input.tdei_dataset_id%>"
+                        },
+                        "data": {
+                            "latest_dataset_url": "<%=decodeURIComponent(tasks.osw_dataset_incline_tag.output.file_upload_path)%>"
+                        }
+                    },
+                    "output_params": {
+                        "success": "<%=success%>",
+                        "message": "<%=message%>"
+                    },
+                    "function": "update_table"
+                },
+                {
+                    "name": "osw_incline_tag_osm_formatting",
+                    "task_reference_name": "osw_incline_tag_osm_formatting",
+                    "description": "Formating the updated dataset to osm",
+                    "type": "Event",
+                    "topic": "osw-formatting-request",
+                    "input_params": {
+                        "user_id": "<%=workflow_input.user_id%>",
+                        "tdei_project_group_id": "<%=workflow_input.tdei_project_group_id%>",
+                        "file_upload_path": "<%=decodeURIComponent(tasks.osw_dataset_incline_tag.output.file_upload_path)%>"
+                    },
+                    "output_params": {
+                        "success": "<%=data.success%>",
+                        "message": "<%=data.message%>",
+                        "formatted_url": "<%=data.formatted_url%>"
+                    }
+                },
+                {
+                    "name": "update_osm_db_incline_tag",
+                    "task_reference_name": "update_osm_db_incline_tag",
+                    "description": "Updating the dataset osm file url",
+                    "type": "Utility",
+                    "input_params": {
+                        "table": "content.dataset",
+                        "where": {
+                            "tdei_dataset_id": "<%=workflow_input.tdei_dataset_id%>"
+                        },
+                        "data": {
+                            "latest_osm_url": "<%=decodeURIComponent(tasks.osw_incline_tag_osm_formatting.output.formatted_url)%>"
+                        }
+                    },
+                    "output_params": {
+                        "success": "<%=success%>",
+                        "message": "<%=message%>"
+                    },
+                    "function": "update_table"
+                },
+                {
+                    "name": "get_incline_blob_folder_path_wo_ext",
+                    "task_reference_name": "get_incline_blob_folder_path_wo_ext",
+                    "description": "Getting the blob folder path for zip upload",
+                    "type": "Utility",
+                    "input_params": {
+                        "blobUrl": "<%=workflow_input.dataset_url%>",
+                        "identifier": "<%=workflow_input.tdei_dataset_id%>"
+                    },
+                    "output_params": {
+                        "success": "<%=success%>",
+                        "message": "<%=message%>",
+                        "folder_path": "<%=folder_path%>"
+                    },
+                    "function": "get_blob_folder_path_wo_ext"
+                },
+                {
+                    "name": "osm_compression_incline_tag",
+                    "task_reference_name": "osm_compression_incline_tag",
+                    "description": "Compressing the osm file",
+                    "type": "Event",
+                    "topic": "dataset-zip-request",
+                    "input_params": {
+                        "input_urls": "<%= JSON.stringify([decodeURIComponent(tasks.osw_incline_tag_osm_formatting.output.formatted_url), workflow_input.metadata_url, workflow_input.changeset_url]) %>",
+                        "output_path": "<%=decodeURIComponent(tasks.get_incline_blob_folder_path_wo_ext.output.folder_path)%>.osm.zip"
+                    },
+                    "output_params": {
+                        "success": "<%=data.success%>",
+                        "message": "<%=data.message%>",
+                        "output_path": "<%=data.output_path%>"
+                    }
+                },
+                {
+                    "name": "update_osm_download_url_db_incline_tag",
+                    "task_reference_name": "update_osm_download_url_db_incline_tag",
+                    "description": "Updating the dataset osm dataset download url",
+                    "type": "Utility",
+                    "input_params": {
+                        "table": "content.dataset",
+                        "where": {
+                            "tdei_dataset_id": "<%=workflow_input.tdei_dataset_id%>"
+                        },
+                        "data": {
+                            "dataset_osm_download_url": "<%=tasks.osm_compression_incline_tag.output.output_path%>"
+                        }
+                    },
+                    "output_params": {
+                        "success": "<%=success%>",
+                        "message": "<%=message%>"
+                    },
+                    "function": "update_table"
+                },
+                {
+                    "name": "osw_compression_incline_tag",
+                    "task_reference_name": "osw_compression_incline_tag",
+                    "description": "Compressing the osw dataset",
+                    "type": "Event",
+                    "topic": "dataset-zip-request",
+                    "input_params": {
+                        "input_urls": "<%= JSON.stringify([decodeURIComponent(tasks.osw_dataset_incline_tag.output.file_upload_path), workflow_input.metadata_url, workflow_input.changeset_url]) %>",
+                        "output_path": "<%=decodeURIComponent(tasks.get_incline_blob_folder_path_wo_ext.output.folder_path)%>.osw.zip"
+                    },
+                    "output_params": {
+                        "success": "<%=data.success%>",
+                        "message": "<%=data.message%>",
+                        "output_path": "<%=data.output_path%>"
+                    }
+                },
+                {
+                    "name": "update_osw_db_incline_tag",
+                    "task_reference_name": "update_osw_db_incline_tag",
+                    "description": "Updating the dataset download url",
+                    "type": "Utility",
+                    "input_params": {
+                        "table": "content.dataset",
+                        "where": {
+                            "tdei_dataset_id": "<%=workflow_input.tdei_dataset_id%>"
+                        },
+                        "data": {
+                            "dataset_download_url": "<%=tasks.osw_compression_road_incline.output.output_path%>"
+                        }
+                    },
+                    "output_params": {
+                        "success": "<%=success%>",
+                        "message": "<%=message%>"
+                    },
+                    "function": "update_table"
+                },
+                {
+                    "name": "update_osw_db_incline_tag_job",
+                    "task_reference_name": "update_osw_db_incline_tag_job",
+                    "description": "Updating the job details",
+                    "type": "Utility",
+                    "input_params": {
+                        "table": "content.job",
+                        "where": {
+                            "job_id": "<%=workflow_input.job_id%>"
+                        },
+                        "data": {
+                            "download_url": "<%=decodeURIComponent(tasks.osw_compression_incline_tag.output.output_path)%>",
+                            "status": "COMPLETED",
+                            "message": "Job Completed Successfully"
+                        }
+                    },
+                    "output_params": {
+                        "success": "<%=success%>",
+                        "message": "<%=message%>"
+                    },
+                    "function": "update_table"
+                }
+            ],
+            "exception_task": [
+                {
+                    "name": "job_failure_db",
+                    "task_reference_name": "job_failure_db",
+                    "description": "Updating the job details on failure",
+                    "type": "Exception",
+                    "input_params": {
+                        "table": "content.job",
+                        "where": {
+                            "job_id": "<%=workflow_input.job_id%>"
+                        },
+                        "data": {
+                            "status": "FAILED"
+                        }
+                    },
+                    "output_params": {
+                        "success": "<%=success%>",
+                        "message": "<%=message%>"
+                    },
+                    "function": "update_table"
+                }
+            ]
         }
     ],
     "subscriptions": [
@@ -2111,6 +2332,11 @@
         {
             "description": "Subscription for osw quality metrics completion",
             "topic": "osw-quality-response",
+            "subscription": "res-handler"
+        },
+        {
+            "description": "Subscription for inclination to be added to the dataset",
+            "topic": "osw-incline-response",
             "subscription": "res-handler"
         }
     ]


### PR DESCRIPTION
**Incline Servic:** 

- The service would take a `dataset_id`
- It will fetch the `latest_dataset_url` from DB for that particular `dataset_id`
    ```
    const dataset = await this.tdeiCoreServiceInstance.getDatasetDetailsById(backendRequest.parameters.dataset_id);
    ```
- Service will trigger the workflow:
  - Sends the message in `osw-incline-request` topic with payload
      ```json
      "jobId": "<%=JSON.stringify(workflow_input.job_id)%>",
      "user_id": "<%=workflow_input.user_id%>",
      "dataset_url": "<%=workflow_input.dataset_url%>"
      ```
  - Once it receives the output:
     ```json
      "success": "<%=data.success%>",
      "message": "<%=data.message%>",
      "file_upload_path": "<%=data.file_upload_path%>"
      ```
  - Update the DB with `latest_dataset_url` got from output
  - Does the OSW to OSM formatting
  - Update the `latest_osm_url` with latest inclination tags
  - Update the `dataset_osm_download_url` 
  - Update the `dataset_download_url`
  - Finally Update the job status to `Completed`
