### PR TITLE
Route change

### DIFF
--- a/src/controller/osw-controller.ts
+++ b/src/controller/osw-controller.ts
@@ -143,7 +143,7 @@ class OSWController implements IController {
         this.router.post(`${this.path}/dataset-tag-road`, authenticate, this.processDatasetTagRoadRequest);
         this.router.post(`${this.path}/spatial-join`, authenticate, this.processSpatialQueryRequest);
         // Route for quality metric request
-        this.router.post(`${this.path}/quality-metric/:tdei_dataset_id`, qualityUpload.single('file'), authenticate, this.createQualityOnDemandRequest);
+        this.router.post(`${this.path}/quality-metric/ixn/:tdei_dataset_id`, qualityUpload.single('file'), authenticate, this.createIXNQualityOnDemandRequest);
         this.router.post(`${this.path}/quality-metric/tag/:tdei_dataset_id`, tagQuality.single('file'), authenticate, this.tagQualityMetric);
     }
 
@@ -540,18 +540,19 @@ class OSWController implements IController {
         }
     }
 
-    createQualityOnDemandRequest = async (request: Request, response: express.Response, next: NextFunction) => {
+    createIXNQualityOnDemandRequest = async (request: Request, response: express.Response, next: NextFunction) => {
         try {
             let tdei_dataset_id = request.params["tdei_dataset_id"];
             const subRegionFile = request.file;
-            let algorithms = request.body.algorithm;
+            // Algorithm is ixn
+            let algorithms = 'ixn';
             // let persist = request.body.persist;
             if (tdei_dataset_id == undefined) {
                 throw new InputException("Missing tdei_dataset_id input")
             }
-            if (tdei_dataset_id == undefined || algorithms == undefined) {
-                throw new InputException("Please add tdei_dataset_id, algorithm in payload")
-            }
+            // if (tdei_dataset_id == undefined || algorithms == undefined) {
+            //     throw new InputException("Please add tdei_dataset_id, algorithm in payload")
+            // }
             let job_id = await oswService.calculateQualityMetric(tdei_dataset_id, algorithms, subRegionFile, request.body.user_id);
             response.setHeader('Location', `/api/v1/job?job_id=${job_id}`);
             return response.status(202).send(job_id);

--- a/test/unit/osw.controller.test.ts
+++ b/test/unit/osw.controller.test.ts
@@ -777,7 +777,7 @@ describe("OSW Controller Test", () => {
             // Mock the calculateQualityMetric function to return mock job_id
             jest.spyOn(oswService, "calculateQualityMetric").mockResolvedValueOnce(mockJobId);
 
-            await oswController.createQualityOnDemandRequest(mockRequest, mockResponse, mockNext);
+            await oswController.createIXNQualityOnDemandRequest(mockRequest, mockResponse, mockNext);
 
             // expect(mockResponse.setHeader).toHaveBeenCalledWith('Location', '/api/v1/job?job_id=mock-job-id');
             expect(mockResponse.status).toHaveBeenCalledWith(202);
@@ -789,7 +789,7 @@ describe("OSW Controller Test", () => {
             // Simulate missing tdei_dataset_id input
             mockRequest.params.tdei_dataset_id = undefined;
 
-            await oswController.createQualityOnDemandRequest(mockRequest, mockResponse, mockNext);
+            await oswController.createIXNQualityOnDemandRequest(mockRequest, mockResponse, mockNext);
 
             expect(mockResponse.status).toHaveBeenCalledWith(400);
             expect(mockResponse.send).toHaveBeenCalledWith('Missing tdei_dataset_id input');
@@ -801,7 +801,7 @@ describe("OSW Controller Test", () => {
             const mockError = new Error('Error while processing the quality metric');
             jest.spyOn(oswService, "calculateQualityMetric").mockRejectedValueOnce(mockError);
 
-            await oswController.createQualityOnDemandRequest(mockRequest, mockResponse, mockNext);
+            await oswController.createIXNQualityOnDemandRequest(mockRequest, mockResponse, mockNext);
 
             expect(mockResponse.status).toHaveBeenCalledWith(500);
             expect(mockResponse.send).toHaveBeenCalledWith('Error while processing the quality metric');


### PR DESCRIPTION
- Quality metric for ixn is changed
- Route is changed and the flow remains the same.
- Unit tests pass

Previous API route:
`/api/v1/osw/quality-metric/<dataset id>`  with `algorithm` name and optional `file` geojson in the payload


New route:
`/api/v1/osw/quality-metric/ixn/<dataset id>` with optional `file` geojson in the payload. The algorithm is not needed