### PR TITLE
Update tdei-orchestrator-config_v2.json

### DIFF
--- a/src/tdei-orchestrator-config_v2.json
+++ b/src/tdei-orchestrator-config_v2.json
@@ -2032,6 +2032,7 @@
                                 "dataset_url": "<%=tasks.osw_quality_metric_on_demand.output.dataset_url%>",
                                 "qm_dataset_url": "<%=tasks.osw_quality_metric_on_demand.output.qm_dataset_url%>"
                             },
+                            "download_url": "<%=tasks.osw_quality_metric_on_demand.output.qm_dataset_url%>",
                             "updated_at": "CURRENT_TIMESTAMP",
                             "status": "COMPLETED"
                         }


### PR DESCRIPTION
Adds download url to the qm fix.
Fixes the issue with 1279 (downloadable link)
There will be a change in the front end also