### PR TITLE
Feature 1359

### DIFF
--- a/db-management/migrations/sqls/20241022095559-metadata-change-up.sql
+++ b/db-management/migrations/sqls/20241022095559-metadata-change-up.sql
@@ -4,3 +4,21 @@ SET metadata_json = jsonb_set(
     '{key_limitations}', (metadata_json->'key_limitations_of_the_dataset')::jsonb
 )::json
 WHERE metadata_json::jsonb ? 'key_limitations_of_the_dataset' ;
+
+
+CREATE OR REPLACE FUNCTION content.tdei_json_read_date(
+	json_data json,
+	key_name text)
+    RETURNS timestamp without time zone
+    LANGUAGE 'plpgsql'
+    COST 100
+    IMMUTABLE PARALLEL UNSAFE
+AS $BODY$
+BEGIN
+    IF json_data ->> key_name IS NOT NULL THEN
+        RETURN (json_data ->> key_name)::timestamp without time zone;
+    ELSE
+        RETURN null;
+    END IF;
+END;
+$BODY$;

--- a/src/service/osw-service.ts
+++ b/src/service/osw-service.ts
@@ -902,8 +902,16 @@ class OswService implements IOswService {
             //flatten the metadata to level 1
             metadata = MetadataModel.flatten(metadata);
             metadata.collection_date = TdeiDate.UTC(metadata.collection_date);
-            metadata.valid_from = TdeiDate.UTC(metadata.valid_from);
-            metadata.valid_to = TdeiDate.UTC(metadata.valid_to);
+
+            if (metadata.valid_from && metadata.valid_from.trim() != "")
+                metadata.valid_from = TdeiDate.UTC(metadata.valid_from);
+            else
+                metadata.valid_from = null;
+
+            if (metadata.valid_to && metadata.valid_to.trim() != "")
+                metadata.valid_to = TdeiDate.UTC(metadata.valid_to);
+            else
+                metadata.valid_to = null;
             //Add metadata to the entity
             datasetEntity.metadata_json = metadata;
             await this.tdeiCoreServiceInstance.createDataset(datasetEntity);

--- a/src/service/tdei-core-service.ts
+++ b/src/service/tdei-core-service.ts
@@ -142,8 +142,26 @@ class TdeiCoreService implements ITdeiCoreService {
         await this.validateMetadata(metadata, data_type, tdei_dataset_id);
         //Date handling
         metadata.dataset_detail.collection_date = TdeiDate.UTC(metadata.dataset_detail.collection_date);
-        metadata.dataset_detail.valid_from = TdeiDate.UTC(metadata.dataset_detail.valid_from);
-        metadata.dataset_detail.valid_to = TdeiDate.UTC(metadata.dataset_detail.valid_to);
+
+        //Valid from and valid to fields are mandatory when record in publish state
+        if (dataset_to_be_edited.status == RecordStatus["Publish"] &&
+            (!metadata.dataset_detail.valid_from || !metadata.dataset_detail.valid_to)) {
+            {
+                throw new InputException(`Valid from and valid to dates are required for publishing the dataset.`);
+            }
+        }
+
+        if (metadata.dataset_detail.valid_from && metadata.dataset_detail.valid_to?.trim() != "")
+            metadata.dataset_detail.valid_from = TdeiDate.UTC(metadata.dataset_detail.valid_from);
+        else
+            metadata.dataset_detail.valid_from = null;
+
+        if (metadata.dataset_detail.valid_to && metadata.dataset_detail.valid_to?.trim() != "")
+            metadata.dataset_detail.valid_to = TdeiDate.UTC(metadata.dataset_detail.valid_to);
+        else
+            metadata.dataset_detail.valid_to = null;
+
+
         //Update the metadata
         const query = {
             text: 'UPDATE content.dataset SET metadata_json = $1, updated_at = CURRENT_TIMESTAMP , updated_by = $2 WHERE tdei_dataset_id = $3',


### PR DESCRIPTION
https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/1359/

On Edit metadata making valid from and to mandatory if dataset status is in publish state.
On upload behaviour change from assigning default valid from and to , changed to assign null if not provided information
