### PR TITLE
union performance changes

### DIFF
--- a/db-management/migrations/sqls/20241106074756-union-perf-improve-up.sql
+++ b/db-management/migrations/sqls/20241106074756-union-perf-improve-up.sql
@@ -76,7 +76,7 @@ BEGIN
 	JOIN content.node AS R   
 	ON U.tdei_dataset_id = SRC_ONE_TDEI_DATASET_ID
 	   AND R.tdei_dataset_id = SRC_TWO_TDEI_DATASET_ID
-	   AND ST_DWithin(ST_Transform(U.node_loc_3857, 3857), ST_Transform(R.node_loc_3857, 3857), 0.5);
+	   AND ST_DWithin(U.node_loc_3857, R.node_loc_3857, 0.5);
 	
 	
 	CREATE TEMP TABLE witness_nodes ON COMMIT DROP AS

--- a/db-management/migrations/sqls/20241106074756-union-perf-improve-up.sql
+++ b/db-management/migrations/sqls/20241106074756-union-perf-improve-up.sql
@@ -52,6 +52,7 @@ ADD COLUMN IF NOT EXISTS zone_loc_3857 geometry(Polygon, 3857)
 	
 CREATE INDEX IF NOT EXISTS idx_zone_loc_3857_gist ON content.zone USING GIST (zone_loc_3857);
 
+--Replacing the 4326 location with 3857 computed column to avoid the transformation in the query
 CREATE OR REPLACE FUNCTION content.tdei_union_dataset(
 	src_one_tdei_dataset_id character varying,
 	src_two_tdei_dataset_id character varying)
@@ -452,7 +453,7 @@ $BODY$;
 
 
 
---Replacing the 4326 location with 3857 coputed column to avoid the transformation in the query
+--Replacing the 4326 location with 3857 computed column to avoid the transformation in the query
 CREATE OR REPLACE FUNCTION content.tdei_update_osw_stats(
 	p_tdei_dataset_id character varying)
     RETURNS void


### PR DESCRIPTION
Task: https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/1466/ 

--Area_union column is redundant. This was introduced to keep for future calculations.
-- Renaming the existing indexes to have proper names
-- Adding new indexes to improve the performance queries tdei_dataset_id on edge,zone,node table
-- Adding new columns to store the geometry in 3857 SRID for edge, node, zone table
-- Function **tdei_update_osw_stats** : Replacing the 4326 location with 3857 computed column to avoid the transformation in the query
-- Function **tdei_union** : Replacing the 4326 location with 3857 computed column to avoid the transformation in the query

<img width="1608" alt="report" src="https://github.com/user-attachments/assets/4ae77788-9d4a-4507-b869-04a3fb65f09b">

