### PR TITLE
Bug fix 1493, 1491

### DIFF
--- a/db-management/migrations/20241127171916-spatial-join-fix.js
+++ b/db-management/migrations/20241127171916-spatial-join-fix.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20241127171916-spatial-join-fix-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20241127171916-spatial-join-fix-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/db-management/migrations/20241202164754-union-upload-fix.js
+++ b/db-management/migrations/20241202164754-union-upload-fix.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20241202164754-union-upload-fix-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20241202164754-union-upload-fix-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/db-management/migrations/sqls/20241127171916-spatial-join-fix-down.sql
+++ b/db-management/migrations/sqls/20241127171916-spatial-join-fix-down.sql
@@ -1,0 +1,1 @@
+/* Replace with your SQL commands */

--- a/db-management/migrations/sqls/20241127171916-spatial-join-fix-up.sql
+++ b/db-management/migrations/sqls/20241127171916-spatial-join-fix-up.sql
@@ -1,0 +1,331 @@
+CREATE OR REPLACE FUNCTION content.tdei_dataset_spatial_join(
+	destination_dataset_id text,
+	dynamic_query text,
+	destination_element text)
+    RETURNS TABLE(edges json, nodes json, zones json, extensions_points json, extensions_lines json, extensions_polygons json) 
+    LANGUAGE 'plpgsql'
+    COST 100
+    VOLATILE PARALLEL UNSAFE
+    ROWS 1000
+
+AS $BODY$
+DECLARE
+    temp_row RECORD;
+BEGIN
+
+    -- Execute the dynamic query to create a temporary table
+    EXECUTE 'CREATE TEMP TABLE temp_dataset_join_result AS ' || dynamic_query;
+
+IF destination_element = 'edge' THEN
+    -- Iterate over intersected edges
+    FOR temp_row IN
+        SELECT feature
+        FROM temp_dataset_join_result
+    LOOP
+        edges := temp_row.feature::jsonb;
+		nodes := null;
+		zones := null;
+		extensions_points := null;
+		extensions_lines := null;
+		extensions_polygons := null;
+        RETURN NEXT;
+    END LOOP; 
+
+    -- Iterate over intersected nodes
+    FOR temp_row IN
+        SELECT n.feature
+        FROM content.node n
+        JOIN (
+            SELECT orig_node_id AS node_id FROM temp_dataset_join_result
+            UNION ALL
+            SELECT dest_node_id AS node_id FROM temp_dataset_join_result
+        ) e ON n.node_id = e.node_id
+		WHERE n.tdei_dataset_id = destination_dataset_id
+		ORDER BY n.node_id ASC
+    LOOP
+        edges := null;
+		nodes := temp_row.feature::jsonb;
+		zones := null;
+		extensions_points := null;
+		extensions_lines := null;
+		extensions_polygons := null;
+        RETURN NEXT;
+    END LOOP;
+
+       -- Pull all the zone intersecting the bbox
+	FOR temp_row IN
+     	SELECT z.feature
+		FROM content.zone z
+        INNER JOIN temp_dataset_join_result ON ST_Intersects(z.zone_loc, temp_dataset_join_result.edge_loc)
+	    WHERE z.tdei_dataset_id = destination_dataset_id
+		ORDER by zone_id ASC
+    LOOP
+        edges := null;
+		nodes := null;
+		zones := temp_row.feature::jsonb;
+		extensions_points := null;
+		extensions_lines := null;
+		extensions_polygons := null;
+        RETURN NEXT;
+    END LOOP;
+	
+	-- Pull all the point extension intersecting the bbox
+	FOR temp_row IN
+        SELECT n.feature
+        FROM content.extension_point n
+        WHERE n.tdei_dataset_id = destination_dataset_id
+		ORDER by n.point_id ASC
+    LOOP
+         edges := null;
+		nodes := null;
+		zones := null;
+		extensions_points := temp_row.feature::jsonb;
+		extensions_lines := null;
+		extensions_polygons := null;
+        RETURN NEXT;
+    END LOOP;
+
+	-- Pull all the line extension intersecting the bbox
+	FOR temp_row IN
+        SELECT n.feature
+        FROM content.extension_line n
+        WHERE n.tdei_dataset_id = destination_dataset_id
+		ORDER by line_id ASC
+    LOOP
+         edges := null;
+		nodes := null;
+		zones := null;
+		extensions_points := null;
+		extensions_lines := temp_row.feature::jsonb;
+		extensions_polygons := null;
+        RETURN NEXT;
+    END LOOP;
+	
+	-- Pull all the polygon extension intersecting the bbox
+	FOR temp_row IN
+        SELECT n.feature
+        FROM content.extension_polygon n
+        WHERE n.tdei_dataset_id = destination_dataset_id
+		ORDER by polygon_id ASC
+    LOOP
+        edges := null;
+		nodes := null;
+		zones := null;
+		extensions_points := null;
+		extensions_lines := null;
+		extensions_polygons := temp_row.feature::jsonb;
+        RETURN NEXT;
+    END LOOP;
+END IF;
+	
+IF destination_element = 'node' THEN
+
+    CREATE TEMP TABLE temp_intersected_edges AS
+    SELECT e.orig_node_id, e.dest_node_id, e.feature, e.edge_loc
+    FROM content.edge e
+    INNER JOIN temp_dataset_join_result node ON e.orig_node_id = node.node_id OR e.dest_node_id = node.node_id
+	WHERE e.tdei_dataset_id = destination_dataset_id
+    ORDER by edge_id ASC;
+
+    -- Iterate over intersected edges
+    FOR temp_row IN
+        SELECT feature
+        FROM content.temp_intersected_edges e
+    LOOP
+        edges := temp_row.feature::jsonb;
+		nodes := null;
+		zones := null;
+		extensions_points := null;
+		extensions_lines := null;
+		extensions_polygons := null;
+        RETURN NEXT;
+    END LOOP; 
+
+    -- Iterate over intersected nodes
+    FOR temp_row IN
+        SELECT n.feature
+        FROM temp_dataset_join_result n
+		ORDER BY n.node_id ASC
+    LOOP
+        edges := null;
+		nodes := temp_row.feature::jsonb;
+		zones := null;
+		extensions_points := null;
+		extensions_lines := null;
+		extensions_polygons := null;
+        RETURN NEXT;
+    END LOOP;
+
+       -- Pull all the zone intersecting the bbox
+	FOR temp_row IN
+     	SELECT z.feature
+		FROM content.zone z
+        INNER JOIN temp_dataset_join_result ON ST_Intersects(z.zone_loc, temp_dataset_join_result.edge_loc)
+	    WHERE z.tdei_dataset_id = destination_dataset_id
+		ORDER by zone_id ASC
+    LOOP
+        edges := null;
+		nodes := null;
+		zones := temp_row.feature::jsonb;
+		extensions_points := null;
+		extensions_lines := null;
+		extensions_polygons := null;
+        RETURN NEXT;
+    END LOOP;
+	
+	-- Pull all the point extension intersecting the bbox
+	FOR temp_row IN
+        SELECT n.feature
+        FROM content.extension_point n
+        WHERE n.tdei_dataset_id = destination_dataset_id
+		ORDER by n.point_id ASC
+    LOOP
+         edges := null;
+		nodes := null;
+		zones := null;
+		extensions_points := temp_row.feature::jsonb;
+		extensions_lines := null;
+		extensions_polygons := null;
+        RETURN NEXT;
+    END LOOP;
+
+	-- Pull all the line extension intersecting the bbox
+	FOR temp_row IN
+        SELECT n.feature
+        FROM content.extension_line n
+        WHERE n.tdei_dataset_id = destination_dataset_id
+		ORDER by line_id ASC
+    LOOP
+         edges := null;
+		nodes := null;
+		zones := null;
+		extensions_points := null;
+		extensions_lines := temp_row.feature::jsonb;
+		extensions_polygons := null;
+        RETURN NEXT;
+    END LOOP;
+	
+	-- Pull all the polygon extension intersecting the bbox
+	FOR temp_row IN
+        SELECT n.feature
+        FROM content.extension_polygon n
+        WHERE n.tdei_dataset_id = destination_dataset_id
+		ORDER by polygon_id ASC
+    LOOP
+        edges := null;
+		nodes := null;
+		zones := null;
+		extensions_points := null;
+		extensions_lines := null;
+		extensions_polygons := temp_row.feature::jsonb;
+        RETURN NEXT;
+    END LOOP;
+END IF;
+
+IF destination_element = 'zone' THEN
+    -- Iterate over intersected edges
+    FOR temp_row IN
+        SELECT feature
+        FROM content.edge e
+        INNER JOIN temp_dataset_join_result z ON ST_Intersects(z.zone_loc, e.edge_loc)
+        WHERE e.tdei_dataset_id = destination_dataset_id
+		ORDER BY e.edge_id ASC
+    LOOP
+        edges := temp_row.feature::jsonb;
+		nodes := null;
+		zones := null;
+		extensions_points := null;
+		extensions_lines := null;
+		extensions_polygons := null;
+        RETURN NEXT;
+    END LOOP; 
+
+    -- Iterate over intersected nodes
+    FOR temp_row IN
+    	SELECT n.feature
+        FROM content.node n
+        JOIN (
+            SELECT unnest(node_ids) FROM temp_dataset_join_result
+        ) e ON n.node_id = e.node_id
+		WHERE n.tdei_dataset_id = destination_dataset_id
+		ORDER BY n.node_id ASC
+    LOOP
+        edges := null;
+		nodes := temp_row.feature::jsonb;
+		zones := null;
+		extensions_points := null;
+		extensions_lines := null;
+		extensions_polygons := null;
+        RETURN NEXT;
+    END LOOP;
+
+       -- Pull all the zone intersecting the bbox
+	FOR temp_row IN
+     	SELECT z.feature
+		FROM temp_dataset_join_result z
+		ORDER by zone_id ASC
+    LOOP
+        edges := null;
+		nodes := null;
+		zones := temp_row.feature::jsonb;
+		extensions_points := null;
+		extensions_lines := null;
+		extensions_polygons := null;
+        RETURN NEXT;
+    END LOOP;
+	
+	-- Pull all the point extension intersecting the bbox
+	FOR temp_row IN
+        SELECT n.feature
+        FROM content.extension_point n
+        WHERE n.tdei_dataset_id = destination_dataset_id
+		ORDER by n.point_id ASC
+    LOOP
+        edges := null;
+		nodes := null;
+		zones := null;
+		extensions_points := temp_row.feature::jsonb;
+		extensions_lines := null;
+		extensions_polygons := null;
+        RETURN NEXT;
+    END LOOP;
+
+	-- Pull all the line extension intersecting the bbox
+	FOR temp_row IN
+        SELECT n.feature
+        FROM content.extension_line n
+        WHERE n.tdei_dataset_id = destination_dataset_id
+		ORDER by line_id ASC
+    LOOP
+         edges := null;
+		nodes := null;
+		zones := null;
+		extensions_points := null;
+		extensions_lines := temp_row.feature::jsonb;
+		extensions_polygons := null;
+        RETURN NEXT;
+    END LOOP;
+	
+	-- Pull all the polygon extension intersecting the bbox
+	FOR temp_row IN
+        SELECT n.feature
+        FROM content.extension_polygon n
+        WHERE n.tdei_dataset_id = destination_dataset_id
+		ORDER by polygon_id ASC
+    LOOP
+        edges := null;
+		nodes := null;
+		zones := null;
+		extensions_points := null;
+		extensions_lines := null;
+		extensions_polygons := temp_row.feature::jsonb;
+        RETURN NEXT;
+    END LOOP;
+END IF;
+
+    -- Drop the temporary table
+    DROP TABLE IF EXISTS temp_dataset_join_result;
+
+    RETURN;
+END;
+$BODY$;

--- a/db-management/migrations/sqls/20241202164754-union-upload-fix-down.sql
+++ b/db-management/migrations/sqls/20241202164754-union-upload-fix-down.sql
@@ -1,0 +1,1 @@
+/* Replace with your SQL commands */

--- a/db-management/migrations/sqls/20241202164754-union-upload-fix-up.sql
+++ b/db-management/migrations/sqls/20241202164754-union-upload-fix-up.sql
@@ -1,0 +1,379 @@
+CREATE OR REPLACE FUNCTION content.tdei_union_dataset(
+	src_one_tdei_dataset_id character varying,
+	src_two_tdei_dataset_id character varying)
+    RETURNS TABLE(edges json, nodes json, zones json, extensions_points json, extensions_lines json, extensions_polygons json) 
+    LANGUAGE 'plpgsql'
+    COST 100
+    VOLATILE PARALLEL UNSAFE
+    ROWS 1000
+
+AS $BODY$
+DECLARE
+    zone_exists BOOLEAN;
+    temp_row RECORD;
+    row_count BIGINT;
+BEGIN
+    ------------------------------ Nodes -------------------------------------
+	-- RAISE NOTICE 'Node processing started at  % .', clock_timestamp();
+	CREATE TEMP TABLE joined_nodes ON COMMIT DROP AS
+	SELECT U.id as uid, U.node_loc as unode_loc, R.id as rid, R.node_loc as rnode_loc
+	FROM content.node AS U
+	JOIN content.node AS R   
+	ON U.tdei_dataset_id = SRC_ONE_TDEI_DATASET_ID
+	   AND R.tdei_dataset_id = SRC_TWO_TDEI_DATASET_ID
+	   AND ST_DWithin(U.node_loc_3857, R.node_loc_3857, 0.5);
+	
+	
+	CREATE TEMP TABLE witness_nodes ON COMMIT DROP AS
+	SELECT min(rid) as wid, uid
+	FROM joined_nodes
+	GROUP BY uid;
+	
+	CREATE TEMP TABLE temp_node_map ON COMMIT DROP AS
+	SELECT 
+		w.wid as newid, 
+		newpt.node_loc as newloc, 
+		newpt.feature as newfeature, 
+		w.uid as oldid, 
+		oldpt.node_loc as oldloc, 
+		oldpt.feature as oldfeature
+	FROM witness_nodes w
+	JOIN content.node newpt ON newpt.id = w.wid
+	JOIN content.node oldpt ON oldpt.id = w.uid
+	WHERE newpt.tdei_dataset_id IN (SRC_ONE_TDEI_DATASET_ID, SRC_TWO_TDEI_DATASET_ID)
+	  AND oldpt.tdei_dataset_id IN (SRC_ONE_TDEI_DATASET_ID, SRC_TWO_TDEI_DATASET_ID);
+	
+	-- Adding GIST indexes on `newloc` and `oldloc` in `temp_node_map`
+	CREATE INDEX ON temp_node_map USING GIST (newloc);
+	CREATE INDEX ON temp_node_map USING GIST (oldloc);
+
+	-- RAISE NOTICE 'Node processing completed at  % .', clock_timestamp();
+
+------------------------------ Edges -------------------------------------
+		-- RAISE NOTICE 'Edge processing started at %.', clock_timestamp();
+
+	CREATE TEMP TABLE edge_vertices ON COMMIT DROP AS
+	SELECT l.id as edgeid, (pt).geom AS loc, (pt).path[1] AS ord
+	FROM content.edge l, ST_DUMPPOINTS(edge_loc) pt
+	WHERE l.tdei_dataset_id IN (SRC_ONE_TDEI_DATASET_ID, SRC_TWO_TDEI_DATASET_ID);
+	
+	CREATE INDEX ON edge_vertices USING GIST(loc);
+	
+	--*
+	CREATE TEMP TABLE replaced_nodes ON COMMIT DROP AS
+	SELECT l.edgeid, COALESCE(p.newloc, l.loc) AS loc, l.ord
+	FROM edge_vertices l
+	LEFT OUTER JOIN temp_node_map p 
+	    ON l.loc && p.oldloc AND ST_Equals(l.loc, p.oldloc);
+	
+	CREATE INDEX ON replaced_nodes(edgeid);
+	CREATE INDEX ON replaced_nodes USING GIST(loc);
+
+	--- Rebuild Nodes 
+	CREATE TEMP TABLE new_export_nodes ON COMMIT DROP AS
+	SELECT DISTINCT ON (existing_node.node_id) existing_node.id as id, existing_node.node_loc as loc, existing_node.feature
+	FROM replaced_nodes l
+	LEFT OUTER JOIN content.node existing_node 
+	    ON l.loc && existing_node.node_loc AND ST_Equals(l.loc, existing_node.node_loc)
+	WHERE existing_node.id is not null
+	order by existing_node.node_id;
+	
+	CREATE INDEX ON new_export_nodes(id);
+	------[END] Rebuild Nodes
+	
+	CREATE TEMP TABLE reconstruct_edge ON COMMIT DROP AS
+	SELECT l.edgeid AS id, ST_MakeLine(l.loc ORDER BY ord ASC) AS loc
+	FROM replaced_nodes l
+	GROUP BY l.edgeid;
+	
+	CREATE INDEX ON reconstruct_edge(id);
+	
+	CREATE TEMP TABLE new_edge ON COMMIT DROP AS
+	SELECT l.id, l.loc, newedge.feature
+	FROM reconstruct_edge l
+	JOIN content.edge newedge ON l.id = newedge.id;
+	
+	CREATE INDEX ON new_edge(id);
+	
+	CREATE TEMP TABLE temp_repaired_edges ON COMMIT DROP AS
+	SELECT * from new_edge;
+
+	CREATE INDEX ON temp_repaired_edges USING GIST(loc);
+
+	CREATE TEMP TABLE edge_loc_start_end ON COMMIT DROP AS
+	SELECT ST_StartPoint(l.loc) AS s, ST_EndPoint(l.loc) AS e, l.id, l.loc
+	FROM temp_repaired_edges l;
+	
+	CREATE INDEX ON edge_loc_start_end USING GIST(s);
+	CREATE INDEX ON edge_loc_start_end USING GIST(e);
+	CREATE INDEX ON edge_loc_start_end(id);
+
+	CREATE TEMP TABLE witness ON COMMIT DROP AS
+	SELECT s, e, MIN(id) AS wid
+	FROM edge_loc_start_end
+	GROUP BY s, e;
+	
+	CREATE INDEX ON witness USING GIST(s);
+	CREATE INDEX ON witness USING GIST(e);
+	CREATE INDEX ON witness(wid);
+
+	-- Commenting the line merge logic. TODO:: Work on alternative ways to merge
+	-- CREATE TEMP TABLE conflated_edges ON COMMIT DROP AS
+	-- SELECT 
+	-- w.s, w.e, MIN(w.wid) AS wid,
+	-- ST_LineMerge(ST_Union(l.loc)) AS conflated_loc
+	-- FROM witness w
+	-- JOIN edge_loc_start_end l 
+	-- ON ST_Equals(w.s, l.s) AND ST_Equals(w.e, l.e)
+	-- GROUP BY w.s, w.e;
+
+	-- CREATE INDEX ON conflated_edges(wid);
+	-- CREATE INDEX ON conflated_edges USING GIST(conflated_loc);
+ 
+	CREATE TEMP TABLE temp_conflated_edges ON COMMIT DROP AS
+	SELECT 
+	w.wid AS id,  
+	l.loc as loc,
+	--w.conflated_loc AS loc --, 
+	l.feature::jsonb,
+	ROW_NUMBER() OVER (ORDER BY w.wid) AS id_sequence
+	FROM witness w
+	LEFT JOIN (
+		SELECT DISTINCT ON (id) id, feature, loc 
+		FROM temp_repaired_edges
+		ORDER BY id  -- Optionally, you can add a secondary ordering criterion
+	) l ON w.wid = l.id;
+	
+	CREATE TEMP TABLE feature_edges ON COMMIT DROP AS
+	SELECT Distinct ON (id)
+	id as edge_id,
+	jsonb_build_object(
+			'type', 'Feature',
+			'geometry', ST_AsGeoJSON(loc)::json,
+			 'properties', 
+			( jsonb_build_object( '_id', id_sequence::text ) 
+				|| ((feature->'properties') - '_id') 
+			)
+		) AS feature, id_sequence as seq_id
+	FROM temp_conflated_edges
+	Order by id;
+	
+		-- RAISE NOTICE 'Edge processing completed at  % .', clock_timestamp();
+
+-- 	------------------------------ POLYGON -------------------------------------
+	-- RAISE NOTICE 'Polygon processing started at  % .', clock_timestamp();
+
+-- Check if there are records in content.zone for the given dataset IDs
+    SELECT EXISTS (
+        SELECT 1 
+        FROM content.zone l
+        WHERE l.tdei_dataset_id IN (SRC_ONE_TDEI_DATASET_ID, SRC_TWO_TDEI_DATASET_ID) limit 1
+    ) INTO zone_exists;
+
+	 CREATE TEMP TABLE feature_polygons (
+        feature json,
+        id bigint
+    );
+	    RAISE NOTICE 'The table zones has % rows.', zone_exists;
+
+    IF zone_exists THEN
+
+		--   -- For each line, map any old points to its new point 
+    	--   -- and rebuild the line accordingly
+		CREATE TEMP TABLE polygon_vertices ON COMMIT DROP AS
+		SELECT l.id, (pt).geom AS loc, (pt).path[1] AS ring, (pt).path[2] AS ord
+		FROM content.zone l, ST_DUMPPOINTS(zone_loc) pt
+		WHERE l.tdei_dataset_id IN (SRC_ONE_TDEI_DATASET_ID, SRC_TWO_TDEI_DATASET_ID);
+		
+		CREATE INDEX idx_polygon_vertices_loc ON polygon_vertices USING GIST(loc);
+		CREATE INDEX idx_polygon_vertices_id ON polygon_vertices(id);
+
+		CREATE TEMP TABLE replaced_polygon ON COMMIT DROP AS
+		SELECT l.id AS pid, COALESCE(p.newloc, l.loc) AS loc, l.ring, l.ord
+		FROM polygon_vertices l
+		LEFT OUTER JOIN temp_node_map p ON l.loc && p.oldloc AND ST_Equals(l.loc, p.oldloc);
+		
+		CREATE INDEX idx_replaced_polygon_loc ON replaced_polygon USING GIST(loc);
+		CREATE INDEX idx_replaced_polygon_pid ON replaced_polygon(pid);
+
+		CREATE TEMP TABLE makerings ON COMMIT DROP AS
+		SELECT l.pid AS id, l.ring, ST_MakeLine(l.loc ORDER BY ord DESC) AS ringloc
+		FROM replaced_polygon l
+		GROUP BY l.pid, l.ring;
+		
+		CREATE INDEX idx_makerings_ringloc ON makerings USING GIST(ringloc);
+		CREATE INDEX idx_makerings_id ON makerings(id);
+
+		CREATE TEMP TABLE reconstruct_polygon ON COMMIT DROP AS
+		SELECT m.id, ST_BuildArea(ST_Collect(ringloc)) AS loc
+		FROM makerings m
+		GROUP BY m.id;
+		
+		CREATE INDEX idx_reconstruct_polygon_loc ON reconstruct_polygon USING GIST(loc);
+		CREATE INDEX idx_reconstruct_polygon_id ON reconstruct_polygon(id);
+
+		CREATE TEMP TABLE new_polygon ON COMMIT DROP AS
+		SELECT rp.id, rp.loc, newZone.feature
+		FROM reconstruct_polygon rp
+		JOIN content.zone newZone ON rp.id = newZone.id;
+		
+		CREATE INDEX idx_new_polygon_loc ON new_polygon USING GIST(loc);
+		CREATE INDEX idx_new_polygon_id ON new_polygon(id);
+
+		CREATE TEMP TABLE temp_repaired_polygon ON COMMIT DROP AS
+		SELECT * FROM new_polygon;
+
+		CREATE TEMP TABLE unique_poly ON COMMIT DROP AS
+		SELECT MIN(id) AS id, loc
+		FROM temp_repaired_polygon
+		GROUP BY loc;
+		
+		CREATE INDEX idx_unique_poly_loc ON unique_poly USING GIST(loc);
+		CREATE INDEX idx_unique_poly_id ON unique_poly(id);
+
+		CREATE TEMP TABLE joined ON COMMIT DROP AS
+		SELECT a.id AS aid, b.id AS bid
+		FROM unique_poly a, unique_poly b
+		WHERE a.id < b.id
+		AND content.union_matchpoly(a.loc, b.loc, 0.75);
+		
+		CREATE INDEX idx_joined_aid ON joined(aid);
+		CREATE INDEX idx_joined_bid ON joined(bid);
+
+		CREATE TEMP TABLE witness ON COMMIT DROP AS
+		SELECT MIN(aid) AS aid, bid
+		FROM joined
+		GROUP BY bid;
+		
+		CREATE INDEX idx_witness_aid ON witness(aid);
+		CREATE INDEX idx_witness_bid ON witness(bid);
+
+		CREATE TEMP TABLE conflatedpoly ON COMMIT DROP AS
+		SELECT id AS id FROM temp_repaired_polygon  -- all polys
+		EXCEPT
+		SELECT bid FROM witness; -- those that are mapped to a witness
+		
+		CREATE INDEX idx_conflatedpoly_id ON conflatedpoly(id);
+
+		CREATE TEMP TABLE finalpoly ON COMMIT DROP AS
+		SELECT p.*
+		FROM conflatedpoly c
+		JOIN unique_poly p ON c.id = p.id;
+		
+		CREATE INDEX idx_finalpoly_id ON finalpoly(id);
+		CREATE INDEX idx_finalpoly_loc ON finalpoly USING GIST(loc);
+    	CREATE TEMP TABLE temp_conflated_polygons ON COMMIT DROP AS
+             SELECT 
+            w.id,  
+            w.loc, 
+            l.feature::jsonb as feature,
+            ROW_NUMBER() OVER (ORDER BY w.id) AS id_sequence
+            FROM finalpoly w
+            LEFT JOIN (
+                SELECT DISTINCT ON (id) id, feature 
+                FROM temp_repaired_polygon
+                ORDER BY id  
+            ) l ON w.id = l.id;
+    
+	     INSERT INTO feature_polygons( feature, id)
+	   		SELECT 
+			   jsonb_build_object(
+	            'type', 'Feature',
+	            'geometry', ST_AsGeoJSON(loc)::json,
+	            'properties',
+	            ( 
+				jsonb_build_object( '_id', id_sequence::text ) 
+	    			            || 
+					((feature->'properties') - '_id') 
+	            ))
+			AS feature, 
+			id_sequence as id
+	    	FROM temp_conflated_polygons where feature is not null;
+   END IF; 
+   
+    	-- RAISE NOTICE 'Polygon processing completed at  % .', clock_timestamp();
+
+    -- 	------------------------------ Export EDGES -------------------------------------
+    SELECT COUNT(*) INTO row_count FROM feature_edges;
+
+    -- Print the row count
+    RAISE NOTICE 'The table edges has % rows.', row_count;
+    
+ -- Iterate over intersected edges
+    FOR temp_row IN
+        SELECT feature
+        FROM feature_edges
+		WHERE feature is not null
+		ORDER by seq_id ASC
+    LOOP
+        edges := temp_row.feature::jsonb;
+		nodes := null;
+        zones := null;
+		extensions_points := null;
+		extensions_lines := null;
+		extensions_polygons := null;
+        RETURN NEXT;
+    END LOOP;
+
+	   ------------------------------ Export NODES -------------------------------------
+	  CREATE TEMP TABLE feature_nodes ON COMMIT DROP AS
+	SELECT Distinct ON (id)
+	id,
+	jsonb_build_object(
+			'type', 'Feature',
+			'geometry', ST_AsGeoJSON(loc)::json,
+			 'properties', 
+			(feature->'properties')
+		) AS feature
+	FROM new_export_nodes
+	Order by id;
+	
+    SELECT COUNT(*) INTO row_count FROM feature_nodes;
+
+    -- Print the row count
+    RAISE NOTICE 'The table nodes has % rows.', row_count;
+    
+     -- Iterate over intersected edges
+    FOR temp_row IN
+        SELECT feature
+        FROM new_export_nodes
+		WHERE feature is not null
+		ORDER by id ASC
+    LOOP
+        edges := null;
+		nodes := temp_row.feature::jsonb;
+        zones := null;
+		extensions_points := null;
+		extensions_lines := null;
+		extensions_polygons := null;
+        RETURN NEXT;
+    END LOOP;
+    	------------------------------ Export Polygon -------------------------------------
+          
+    -- IF zone_exists THEN
+	SELECT COUNT(*) INTO row_count FROM feature_polygons;
+
+	-- Print the row count
+	RAISE NOTICE 'The table polygon has % rows.', row_count;
+
+	FOR temp_row IN
+		SELECT feature
+		FROM feature_polygons
+		WHERE feature is not null
+		ORDER by id ASC
+	LOOP
+		edges := null;
+		nodes := null;
+		zones := temp_row.feature::jsonb;
+		extensions_points := null;
+		extensions_lines := null;
+		extensions_polygons := null;
+		RETURN NEXT;
+	END LOOP;
+
+ -- Drop the temporary table
+    DROP TABLE IF EXISTS feature_polygons;
+     
+RETURN;
+END;
+$BODY$;

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test:coverage": "jest --coverage",
     "build": "rimraf ./build && tsc",
     "migrate": "npx db-migrate up",
-    "start": "npm run migrate && npm run build  && npm run copy:assets && node build/src/server.js",
+    "start": "npm run build  && npm run copy:assets && node build/src/server.js",
     "start-prod": "npm run migrate && node build/src/server.js",
     "start:dev": "nodemon",
     "copy:assets": "cp -r 'src/assets/' 'build/src/assets/'",

--- a/src/orchestrator_v2/task/task-functions.ts
+++ b/src/orchestrator_v2/task/task-functions.ts
@@ -7,7 +7,7 @@ export class OrchestratorFunctions {
     constructor() { }
 
 
-    public static async bbox_response_validation(input: any): Promise<any> {
+    public static async backed_service_response_validation(input: any): Promise<any> {
         try {
             if (input.success && input.file_upload_path.length == 0) {
                 //Terminate the workflow as no further processing is required
@@ -34,13 +34,13 @@ export class OrchestratorFunctions {
             else {
                 return Promise.resolve({
                     success: true,
-                    message: "Bbox response validated successfully"
+                    message: `${input.service} response validated successfully`
                 });
             }
         } catch (error) {
             return Promise.resolve({
                 success: false,
-                message: "Error while validating the bbox response"
+                message: `Error while validating the ${input.service} response`
             });
         }
     }

--- a/src/tdei-orchestrator-config_v2.json
+++ b/src/tdei-orchestrator-config_v2.json
@@ -1139,6 +1139,7 @@
                     "description": "Validating the bbox response",
                     "type": "Utility",
                     "input_params": {
+                        "service": "bbox",
                         "job_id": "<%=workflow_input.job_id%>",
                         "success": "<%=tasks.osm_dataset_bbox.output.success%>",
                         "message": "<%=tasks.osm_dataset_bbox.output.message%>",
@@ -1148,7 +1149,7 @@
                         "success": "<%=success%>",
                         "message": "<%=message%>"
                     },
-                    "function": "bbox_response_validation"
+                    "function": "backed_service_response_validation"
                 },
                 {
                     "name": "osm_dataset_bbox_osm_formatting",
@@ -1264,6 +1265,7 @@
                     "description": "Validating the bbox response",
                     "type": "Utility",
                     "input_params": {
+                        "service": "bbox",
                         "job_id": "<%=workflow_input.job_id%>",
                         "success": "<%=tasks.osw_dataset_bbox.output.success%>",
                         "message": "<%=tasks.osw_dataset_bbox.output.message%>",
@@ -1273,7 +1275,7 @@
                         "success": "<%=success%>",
                         "message": "<%=message%>"
                     },
-                    "function": "bbox_response_validation"
+                    "function": "backed_service_response_validation"
                 },
                 {
                     "name": "osw_compression_bbox",
@@ -1367,20 +1369,22 @@
                     }
                 },
                 {
-                    "name": "osw_compression",
-                    "task_reference_name": "osw_compression",
-                    "description": "Compressing the osw file",
-                    "type": "Event",
-                    "topic": "dataset-zip-request",
+                    "name": "osw_spatial_join_response_validation",
+                    "task_reference_name": "osw_spatial_join_response_validation",
+                    "description": "Validating the spatial_join response",
+                    "type": "Utility",
                     "input_params": {
-                        "input_urls": "<%= JSON.stringify([decodeURIComponent(tasks.osw_spatial_join.output.file_upload_path)]) %>",
-                        "output_path": "<%=decodeURIComponent(tasks.osw_spatial_join.output.file_upload_path)%>.osw.zip"
+                        "service": "spatial_join",
+                        "job_id": "<%=workflow_input.job_id%>",
+                        "success": "<%=tasks.osw_spatial_join.output.success%>",
+                        "message": "<%=tasks.osw_spatial_join.output.message%>",
+                        "file_upload_path": "<%=tasks.osw_spatial_join.output.file_upload_path%>"
                     },
                     "output_params": {
-                        "success": "<%=data.success%>",
-                        "message": "<%=data.message%>",
-                        "output_path": "<%=data.output_path%>"
-                    }
+                        "success": "<%=success%>",
+                        "message": "<%=message%>"
+                    },
+                    "function": "backed_service_response_validation"
                 },
                 {
                     "name": "osm_spatial_join_job_db",
@@ -1393,7 +1397,7 @@
                             "job_id": "<%=workflow_input.job_id%>"
                         },
                         "data": {
-                            "download_url": "<%=decodeURIComponent(tasks.osw_compression.output.output_path)%>",
+                            "download_url": "<%=decodeURIComponent(tasks.osw_spatial_join.output.file_upload_path)%>",
                             "status": "COMPLETED",
                             "message": "Job Completed Successfully",
                             "updated_at": "CURRENT_TIMESTAMP"
@@ -2366,20 +2370,22 @@
                     }
                 },
                 {
-                    "name": "osw_compression",
-                    "task_reference_name": "osw_compression",
-                    "description": "Compressing the osw output file",
-                    "type": "Event",
-                    "topic": "dataset-zip-request",
+                    "name": "osw_union_response_validation",
+                    "task_reference_name": "osw_union_response_validation",
+                    "description": "Validating the union response",
+                    "type": "Utility",
                     "input_params": {
-                        "input_urls": "<%= JSON.stringify([decodeURIComponent(tasks.osw_union.output.file_upload_path)]) %>",
-                        "output_path": "<%=decodeURIComponent(tasks.osw_union.output.file_upload_path)%>.osw.zip"
+                        "service": "union",
+                        "job_id": "<%=workflow_input.job_id%>",
+                        "success": "<%=tasks.osw_union.output.success%>",
+                        "message": "<%=tasks.osw_union.output.message%>",
+                        "file_upload_path": "<%=tasks.osw_union.output.file_upload_path%>"
                     },
                     "output_params": {
-                        "success": "<%=data.success%>",
-                        "message": "<%=data.message%>",
-                        "output_path": "<%=data.output_path%>"
-                    }
+                        "success": "<%=success%>",
+                        "message": "<%=message%>"
+                    },
+                    "function": "backed_service_response_validation"
                 },
                 {
                     "name": "osm_union_join_job_db",
@@ -2392,7 +2398,7 @@
                             "job_id": "<%=workflow_input.job_id%>"
                         },
                         "data": {
-                            "download_url": "<%=decodeURIComponent(tasks.osw_compression.output.output_path)%>",
+                            "download_url": "<%=decodeURIComponent(tasks.osw_union.output.file_upload_path)%>",
                             "status": "COMPLETED",
                             "message": "Job Completed Successfully",
                             "updated_at": "CURRENT_TIMESTAMP"


### PR DESCRIPTION
**Task**: 
https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/1493/ 
https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/1491/

**Union**
	•	**Issue 1**:
Only nodes within 0.5 meters of each other (as per the conflation logic) were being exported, causing re-upload failures due to missing nodes.
**Fix**: Export all participant nodes of the edge (LINESTRING).

  •	**Issue 2**:
In the Union logic, a specific use case where two edges overlap but have different start and end nodes should result in a merge. However, the current implementation outputs a MultiLineString, which is not supported in TDEI.
**Fix**: As per the discussion with Bill, this use case has been temporarily commented out and will be addressed separately in the future. 

**Spatial Join**
	•	**Issue 1**:
Duplicate nodes were being included in the final output, leading to validator errors.
**Fix**: Added a DISTINCT node_id clause to the script to ensure unique nodes are exported.
	•	**Issue 2**:
Exporting large feature JSON objects failed due to inefficient type casting of JSON.
**Fix**: Switched to JSONB for better handling of large JSON objects.

**General**
1.	Double Compression Issue:
Spatial Join and Union workflows applied double compression on output file (backend service exports zipped files, and the data service workflow had additional step to compressed them again).
**Fix**: Updated the workflow to avoid redundant compression.

2. In the case there is no output from Spatial join operation , added additional check to verify such instance and terminate the workflow. 



