### PR TITLE
Updated migration

### DIFF
--- a/db-management/migrations/20250115153003-update-metric_function.js
+++ b/db-management/migrations/20250115153003-update-metric_function.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20250115153003-update-data-metrics-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20250115153003-update-data-metrics-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/db-management/migrations/sqls/20250115153003-update-data-metrics-down.sql
+++ b/db-management/migrations/sqls/20250115153003-update-data-metrics-down.sql
@@ -1,0 +1,126 @@
+-- Update the data metrics function to include the total size of the datasets
+CREATE OR REPLACE FUNCTION content.tdei_fetch_data_metrics()
+RETURNS JSON AS $$
+DECLARE
+    result JSON;
+BEGIN
+    WITH
+        osw_dataset_edges_cte AS (
+            SELECT
+            SUM(num_edges) as num_edges,
+            ROUND(CAST((SUM(length_of_sidewalks_mtr)/1000) AS numeric),2) as length_of_sidewalks_km,
+            SUM(num_crossings) AS num_crossings,
+            SUM(num_nodes) as num_nodes,
+            SUM(area_km2) as area_km2
+            FROM content.osw_stats os
+            INNER JOIN content.dataset ds ON os.tdei_dataset_id = ds.tdei_dataset_id
+            WHERE ds.status not in ('Deleted', 'Draft')
+        ),
+        datset_metric_cte AS (
+            SELECT
+            SUM(CASE WHEN data_type = 'osw' THEN 1 ELSE 0 END) AS osw_totalDatasets,
+            SUM(CASE WHEN data_type = 'flex' THEN 1 ELSE 0 END) AS flex_totalDatasets,
+            SUM(CASE WHEN data_type = 'pathways' THEN 1 ELSE 0 END) AS pathways_totalDatasets,
+            SUM(CASE WHEN data_type = 'osw' THEN upload_file_size_bytes ELSE 0 END) AS osw_totalSizeByt,
+            SUM(CASE WHEN data_type = 'flex' THEN upload_file_size_bytes ELSE 0 END) AS flex_totalSizeByt,
+            SUM(CASE WHEN data_type = 'pathways' THEN upload_file_size_bytes ELSE 0 END) AS pathways_totalSizeByt
+            FROM content.dataset
+            WHERE status not in ('Deleted', 'Draft')
+        )
+
+    SELECT json_build_object(
+        'dataMetrics', json_build_object(
+            'datasetByType' , json_build_object(
+             'osw', json_build_object(
+                'totalDatasets', dmc.osw_totalDatasets,
+                'totalSizeMB', ROUND(dmc.osw_totalSizeByt / 1048576.0, 2),
+                 'aggregatedStats', json_build_object(
+                    'num_crossings', odec.num_crossings,
+                    'length_of_sidewalks_km', odec.length_of_sidewalks_km,
+                    'num_edges', odec.num_edges,
+                    'num_nodes', odec.num_nodes,
+                    'area_km2', ROUND(CAST(odec.area_km2 as DECIMAL),2)
+                )
+            ),
+            'flex', json_build_object(
+                'totalDatasets', dmc.flex_totalDatasets,
+                'totalSizeMB', ROUND(dmc.flex_totalSizeByt / 1048576.0, 2)
+            ),
+             'pathways', json_build_object(
+                'totalDatasets', dmc.pathways_totalDatasets,
+                'totalSizeMB', ROUND(dmc.pathways_totalSizeByt / 1048576.0, 2)
+            )
+          )
+        )
+    ) INTO result
+    FROM osw_dataset_edges_cte odec
+    CROSS JOIN datset_metric_cte dmc;
+
+    RETURN result;
+END;
+$$ LANGUAGE plpgsql;
+
+
+-- Update the system metrics function to include the total size of the datasets
+CREATE OR REPLACE FUNCTION content.tdei_fetch_system_metrics()
+RETURNS JSON AS $$
+DECLARE
+    result JSON;
+BEGIN
+    -- Using CTEs to aggregate metrics from multiple tables
+    WITH
+         dataset_stat_cte AS (
+            SELECT
+            COUNT(tdei_dataset_id) as totaluploads,
+            SUM(upload_file_size_bytes) AS totalSizeByt
+            FROM content.dataset WHERE status not in ('Deleted', 'Draft')
+        ),
+        users_cte AS (
+            SELECT count(Distinct(user_id)) as totalUsers FROM public.user_roles ur
+            INNER JOIN public.roles r ON ur.role_id = r.role_id
+            WHERE r.name != 'tdei_admin'
+        ),
+        project_groups_cte AS (
+            SELECT COUNT(*) as totalProjectGroups FROM public.project_group WHERE is_active = 'true'
+        ),
+        services_cte AS (
+            SELECT
+            COUNT(*) AS totalServices,
+            SUM(CASE WHEN service_type = 'osw' THEN 1 ELSE 0 END) AS osw_count,
+            SUM(CASE WHEN service_type = 'flex' THEN 1 ELSE 0 END) AS flex_count,
+            SUM(CASE WHEN service_type = 'pathways' THEN 1 ELSE 0 END) AS pathways_count
+            FROM public.service WHERE is_active = 'true'
+        )
+    -- Build the JSON result
+    SELECT json_build_object(
+        'systemMetrics', json_build_object(
+            'totalUsers', uc.totalUsers,
+            'totalServices', sc.totalServices,
+            'totalProjectGroups', pgc.totalProjectGroups,
+            'servicesByType', json_build_object(
+                'osw', sc.osw_count,
+                'flex', sc.flex_count,
+                'pathways', sc.pathways_count
+            )
+        ),
+        'datasetMetrics', json_build_object(
+             'totalUploads', json_build_object(
+                'count', dsc.totaluploads,
+                'totalSizeMB', ROUND(dsc.totalSizeByt / 1048576.0, 2)
+            )
+        )
+    ) INTO result
+    FROM users_cte uc
+    CROSS JOIN project_groups_cte pgc
+    CROSS JOIN services_cte sc
+    CROSS JOIN dataset_stat_cte dsc;
+
+    -- Return the result as a JSON array
+    RETURN result;
+END;
+$$ LANGUAGE plpgsql;
+
+
+
+
+

--- a/db-management/migrations/sqls/20250115153003-update-data-metrics-up.sql
+++ b/db-management/migrations/sqls/20250115153003-update-data-metrics-up.sql
@@ -1,0 +1,171 @@
+CREATE OR REPLACE FUNCTION content.tdei_fetch_data_metrics()
+RETURNS JSON AS $$
+DECLARE
+    result JSON;
+BEGIN
+    WITH
+        osw_dataset_edges_cte AS (
+            SELECT
+            SUM(num_edges) as num_edges,
+            ROUND(CAST((SUM(length_of_sidewalks_mtr)/1000) AS numeric),2) as length_of_sidewalks_km,
+            SUM(num_crossings) AS num_crossings,
+            SUM(num_nodes) as num_nodes,
+            SUM(area_km2) as area_km2
+            FROM content.osw_stats os
+            INNER JOIN content.dataset ds ON os.tdei_dataset_id = ds.tdei_dataset_id
+            WHERE ds.status not in ('Deleted', 'Draft')
+        ),
+        datset_metric_cte AS (
+            SELECT
+            SUM(CASE WHEN data_type = 'osw' THEN 1 ELSE 0 END) AS osw_totalDatasets,
+            SUM(CASE WHEN data_type = 'flex' THEN 1 ELSE 0 END) AS flex_totalDatasets,
+            SUM(CASE WHEN data_type = 'pathways' THEN 1 ELSE 0 END) AS pathways_totalDatasets,
+            SUM(CASE WHEN data_type = 'osw' THEN upload_file_size_bytes ELSE 0 END) AS osw_totalSizeByt,
+            SUM(CASE WHEN data_type = 'flex' THEN upload_file_size_bytes ELSE 0 END) AS flex_totalSizeByt,
+            SUM(CASE WHEN data_type = 'pathways' THEN upload_file_size_bytes ELSE 0 END) AS pathways_totalSizeByt
+            FROM content.dataset
+            WHERE status not in ('Deleted', 'Draft')
+        ),
+        download_stats_cte AS (
+            SELECT
+                SUM(CASE WHEN data_type = 'osw' THEN 1 ELSE 0 END) AS osw_totalDownloadDatasets,
+                SUM(CASE WHEN data_type = 'flex' THEN 1 ELSE 0 END) AS flex_totalDownloadDatasets,
+                SUM(CASE WHEN data_type = 'pathways' THEN 1 ELSE 0 END) AS pathways_totalDownloadDatasets,
+                SUM(CASE WHEN data_type = 'osw' THEN file_size ELSE 0 END) AS osw_totalDownloadSizeByt,
+                SUM(CASE WHEN data_type = 'flex' THEN file_size ELSE 0 END) AS flex_totalDownloadSizeByt,
+                SUM(CASE WHEN data_type = 'pathways' THEN file_size ELSE 0 END) AS pathways_totalDownloadSizeByt
+            FROM content.download_stats
+        )
+
+    SELECT json_build_object(
+        'dataMetrics', json_build_object(
+            'datasetByType' , json_build_object(
+             'osw', json_build_object(
+                'totalDatasets', dmc.osw_totalDatasets,
+                'totalSizeMB', ROUND(dmc.osw_totalSizeByt / 1048576.0, 2),
+                'totalDownloadDatasets', dsc.osw_totalDownloadDatasets,
+                'totalDownloadSizeMB', ROUND(dsc.osw_totalDownloadSizeByt / 1048576.0, 2),
+                 'aggregatedStats', json_build_object(
+                    'num_crossings', odec.num_crossings,
+                    'length_of_sidewalks_km', odec.length_of_sidewalks_km,
+                    'num_edges', odec.num_edges,
+                    'num_nodes', odec.num_nodes,
+                    'area_km2', ROUND(CAST(odec.area_km2 as DECIMAL),2)
+                )
+            ),
+            'flex', json_build_object(
+                'totalDatasets', dmc.flex_totalDatasets,
+                'totalSizeMB', ROUND(dmc.flex_totalSizeByt / 1048576.0, 2),
+                'totalDownloadDatasets', dsc.flex_totalDownloadDatasets,
+                'totalDownloadSizeMB', ROUND(dsc.flex_totalDownloadSizeByt / 1048576.0, 2)
+            ),
+             'pathways', json_build_object(
+                'totalDatasets', dmc.pathways_totalDatasets,
+                'totalSizeMB', ROUND(dmc.pathways_totalSizeByt / 1048576.0, 2),
+                'totalDownloadDatasets', dsc.pathways_totalDownloadDatasets,
+                'totalDownloadSizeMB', ROUND(dsc.pathways_totalDownloadSizeByt / 1048576.0, 2)
+            )
+          )
+        )
+    ) INTO result
+    FROM osw_dataset_edges_cte odec
+    CROSS JOIN datset_metric_cte dmc;
+
+    RETURN result;
+END;
+$$ LANGUAGE plpgsql;
+
+
+
+CREATE OR REPLACE FUNCTION content.tdei_fetch_system_metrics()
+RETURNS JSON AS $$
+DECLARE
+    result JSON;
+BEGIN
+    -- Using CTEs to aggregate metrics from multiple tables
+    WITH
+         dataset_stat_cte AS (
+            SELECT
+            COUNT(tdei_dataset_id) as totaluploads,
+            SUM(upload_file_size_bytes) AS totalSizeByt
+            FROM content.dataset WHERE status not in ('Deleted', 'Draft')
+        ),
+        users_cte AS (
+            SELECT count(Distinct(user_id)) as totalUsers FROM public.user_roles ur
+            INNER JOIN public.roles r ON ur.role_id = r.role_id
+            WHERE r.name != 'tdei_admin'
+        ),
+        project_groups_cte AS (
+            SELECT COUNT(*) as totalProjectGroups FROM public.project_group WHERE is_active = 'true'
+        ),
+        services_cte AS (
+            SELECT
+            COUNT(*) AS totalServices,
+            SUM(CASE WHEN service_type = 'osw' THEN 1 ELSE 0 END) AS osw_count,
+            SUM(CASE WHEN service_type = 'flex' THEN 1 ELSE 0 END) AS flex_count,
+            SUM(CASE WHEN service_type = 'pathways' THEN 1 ELSE 0 END) AS pathways_count
+            FROM public.service WHERE is_active = 'true'
+        ),
+        downloads_cte AS (
+            SELECT
+            	  COUNT(*) AS totalDownloads,
+	              SUM(file_size) AS totalDownloadSizeBytes
+    	      FROM content.download_stats
+    	  ),
+		    downloads_per_month_cte AS (
+            SELECT
+                TO_CHAR(requested_datetime, 'YYYY') AS year,
+                TO_CHAR(requested_datetime, 'Month') AS month_name,
+                COUNT(*) AS download_count
+            FROM content.download_stats
+            GROUP BY TO_CHAR(requested_datetime, 'YYYY'), TO_CHAR(requested_datetime, 'Month'),
+                     EXTRACT(YEAR FROM requested_datetime), EXTRACT(MONTH FROM requested_datetime)
+            ORDER BY EXTRACT(YEAR FROM requested_datetime), EXTRACT(MONTH FROM requested_datetime)
+        ),
+        downloads_per_year AS (
+            SELECT
+                year,
+                json_object_agg(month_name, download_count) AS monthly_data
+            FROM downloads_per_month_cte
+            GROUP BY year
+        )
+    -- Build the JSON result
+    SELECT json_build_object(
+        'systemMetrics', json_build_object(
+            'totalUsers', uc.totalUsers,
+            'totalServices', sc.totalServices,
+            'totalProjectGroups', pgc.totalProjectGroups,
+            'servicesByType', json_build_object(
+                'osw', sc.osw_count,
+                'flex', sc.flex_count,
+                'pathways', sc.pathways_count
+            )
+        ),
+        'datasetMetrics', json_build_object(
+             'totalUploads', json_build_object(
+                'count', dsc.totaluploads,
+                'totalSizeMB', ROUND(dsc.totalSizeByt / 1048576.0, 2)
+            ),
+            'totalDownloads', json_build_object(
+            	'count', dc.totalDownloads,
+	            'totalSizeMB', ROUND(dc.totalDownloadSizeBytes / 1048576.0, 2)
+        	  ),
+			      'downloadsPerMonth', (SELECT json_object_agg(year, monthly_data) FROM downloads_per_year)
+        )
+    ) INTO result
+    FROM users_cte uc
+    CROSS JOIN project_groups_cte pgc
+    CROSS JOIN services_cte sc
+    CROSS JOIN dataset_stat_cte dsc
+    CROSS JOIN downloads_cte dc
+	  CROSS JOIN downloads_per_year dpy;
+
+    -- Return the result as a JSON array
+    RETURN result;
+END;
+$$ LANGUAGE plpgsql;
+
+
+
+
+


### PR DESCRIPTION
- Added migration to include the upload dataset count and upload dataset size
- Updated `tdei_fetch_data_metrics` SQL function to include `totalDownloadDatasets` and `totalDownloadSizeMB`,  sample response from function.

    ```
    {
        "dataMetrics": {
            "datasetByType": {
                "osw": {
                    "totalDatasets": 787,
                    "totalSizeMB": 3112.99,
                    "totalDownloadDatasets": 6,
                    "totalDownloadSizeMB": 141.98,
                    "aggregatedStats": {
                        "num_crossings": 1017142,
                        "length_of_sidewalks_km": 8975.42,
                        "num_edges": 5652192,
                        "num_nodes": 6444586,
                        "area_km2": 5559.31
                    }
                },
            "flex": {
                "totalDatasets": 674,
                "totalSizeMB": 4.66,
                "totalDownloadDatasets": 0,
                "totalDownloadSizeMB": 0
            },
            "pathways": {
                "totalDatasets": 557,
                "totalSizeMB": 88.96,
                "totalDownloadDatasets": 0,
                "totalDownloadSizeMB": 0
            }
        }
    }
```


- Updated `tdei_fetch_system_metrics` SQL function to include `totalDownloadDatasets` and `downloadsPerMonth`,  sample response from function.


    ```
    {
        "systemMetrics": {
            "totalUsers": 924,
            "totalServices": 945,
            "totalProjectGroups": 508,
            "servicesByType": {
                "osw": 142,
                "flex": 681,
                "pathways": 122
            }
        },
        "datasetMetrics": {
            "totalUploads": {
                "count": 2011,
                "totalSizeMB": 2902.45
            },
            "totalDownloads": {
                "count": 6,
                "totalSizeMB": 141.98
            },
            "downloadsPerMonth": {
                "2025": {
                    "January  ": 6
                }
        }
    }
```
   

