### PR TITLE
Fixes the issue with abandonned status

### DIFF
--- a/src/orchestrator_v2/task/task-exception-handler.ts
+++ b/src/orchestrator_v2/task/task-exception-handler.ts
@@ -33,6 +33,9 @@ export class TaskExceptionHandler extends workflowBase_v2 {
             }
             // Workaround for abandonned flows
             if(workflow_context.status === WorkflowStatus.ABANDONED) {
+                if (messageInput['data'] == null) {
+                    messageInput['data'] = {};
+                }
                 messageInput['data']['status'] = WorkflowStatus.ABANDONED;
                 messageInput['data']['message'] = workflow_context.current_task_error;
             }

--- a/src/tdei-orchestrator-config_v2.json
+++ b/src/tdei-orchestrator-config_v2.json
@@ -242,7 +242,8 @@
                             "job_id": "<%=workflow_input.job_id%>"
                         },
                         "data": {
-                            "status": "FAILED"
+                            "status": "FAILED",
+                            "updated_at": "CURRENT_TIMESTAMP"
                         }
                     },
                     "output_params": {

--- a/test/unit/flex.service.test.ts
+++ b/test/unit/flex.service.test.ts
@@ -12,6 +12,7 @@ import tdeiCoreService from "../../src/service/tdei-core-service";
 import jobService from "../../src/service/job-service";
 import flexService from "../../src/service/flex-service";
 import { ServiceEntity } from "../../src/database/entity/service-entity";
+import { Utility } from "../../src/utility/utility";
 
 // group test using describe
 describe("Flex Service Test", () => {
@@ -237,7 +238,7 @@ describe("Flex Service Test", () => {
             const validateMetadataSpy = jest.spyOn(tdeiCoreService, 'validateMetadata').mockResolvedValue(true);
             const uploadSpy = jest.spyOn(storageService, 'uploadFile').mockResolvedValue("file-path");
             jest.spyOn(storageService, "generateRandomUUID").mockReturnValueOnce('mocked-uuid');
-
+            Utility.calculateTotalSize  = jest.fn().mockReturnValue(1000);
             // Mock the behavior of checkMetaNameAndVersionUnique
             // jest.spyOn(tdeiCoreService, 'checkMetaNameAndVersionUnique').mockResolvedValue(false);
 

--- a/test/unit/osw.service.test.ts
+++ b/test/unit/osw.service.test.ts
@@ -20,6 +20,7 @@ import { CreateJobDTO } from "../../src/model/job-dto";
 import { TDEIDataType, JobType, JobStatus } from "../../src/model/jobs-get-query-params";
 import { WorkflowName } from "../../src/constants/app-constants";
 import { SpatialJoinRequest, UnionRequest } from "../../src/model/request-interfaces";
+import { Utility } from "../../src/utility/utility";
 
 // group test using describe
 describe("OSW Service Test", () => {
@@ -725,6 +726,7 @@ describe("OSW Service Test", () => {
             const validateMetadataSpy = jest.spyOn(tdeiCoreService, 'validateMetadata').mockResolvedValue(true);
             const uploadSpy = jest.spyOn(storageService, 'uploadFile').mockResolvedValue("file-path");
             jest.spyOn(storageService, "generateRandomUUID").mockReturnValueOnce('mocked-uuid');
+            Utility.calculateTotalSize  = jest.fn().mockReturnValue(1000);
 
             // Mock the behavior of checkMetaNameAndVersionUnique
             // jest.spyOn(tdeiCoreService, 'checkMetaNameAndVersionUnique').mockResolvedValue(false);

--- a/test/unit/pathways.service.test.ts
+++ b/test/unit/pathways.service.test.ts
@@ -12,6 +12,7 @@ import tdeiCoreService from "../../src/service/tdei-core-service";
 import jobService from "../../src/service/job-service";
 import pathwaysService from "../../src/service/pathways-service";
 import { ServiceEntity } from "../../src/database/entity/service-entity";
+import { Utility } from "../../src/utility/utility";
 
 // group test using describe
 describe("Pathways Service Test", () => {
@@ -237,6 +238,7 @@ describe("Pathways Service Test", () => {
             const validateMetadataSpy = jest.spyOn(tdeiCoreService, 'validateMetadata').mockResolvedValue(true);
             const uploadSpy = jest.spyOn(storageService, 'uploadFile').mockResolvedValue("file-path");
             jest.spyOn(storageService, "generateRandomUUID").mockReturnValueOnce('mocked-uuid');
+            Utility.calculateTotalSize  = jest.fn().mockReturnValue(1000);
 
             // Mock the behavior of checkMetaNameAndVersionUnique
             // jest.spyOn(tdeiCoreService, 'checkMetaNameAndVersionUnique').mockResolvedValue(false);


### PR DESCRIPTION
- Fixes the error that was throwing exception when trying to abandon a workflow
Error message:

```
Error while handling exception task : osw_upload_failure TypeError:
 Cannot set properties of undefined (setting 'status')
```
This is due to the `data` property being null. 