### PR TITLE
clone datasize update

### DIFF
--- a/src/service/flex-service.ts
+++ b/src/service/flex-service.ts
@@ -390,7 +390,7 @@ class FlexService implements IFlexService {
 
         const downloadStatsEntity = new DownloadStatsEntity();
         downloadStatsEntity.blob_url = download_url;
-        downloadStatsEntity.file_size = dataset.upload_file_size_bytes;
+        downloadStatsEntity.file_size = dataset.upload_file_size_bytes || 0;
         downloadStatsEntity.tdei_dataset_id = dataset.tdei_dataset_id;
         downloadStatsEntity.data_type = TDEIDataType.flex;
         downloadStatsEntity.requested_datetime = new Date().toISOString();

--- a/src/service/osw-service.ts
+++ b/src/service/osw-service.ts
@@ -997,7 +997,7 @@ class OswService implements IOswService {
 
         const downloadStatsEntity = new DownloadStatsEntity();
         downloadStatsEntity.blob_url = dataset_db_url;
-        downloadStatsEntity.file_size = dataset.upload_file_size_bytes;
+        downloadStatsEntity.file_size = dataset.upload_file_size_bytes || 0;
         downloadStatsEntity.tdei_dataset_id = dataset.tdei_dataset_id;
         downloadStatsEntity.data_type = TDEIDataType.osw;
         downloadStatsEntity.requested_datetime = new Date().toISOString();

--- a/src/service/pathways-service.ts
+++ b/src/service/pathways-service.ts
@@ -362,7 +362,7 @@ class PathwaysService implements IPathwaysService {
 
         const downloadStatsEntity = new DownloadStatsEntity();
         downloadStatsEntity.blob_url = download_url;
-        downloadStatsEntity.file_size = dataset.upload_file_size_bytes;
+        downloadStatsEntity.file_size = dataset.upload_file_size_bytes || 0;
         downloadStatsEntity.tdei_dataset_id = dataset.tdei_dataset_id;
         downloadStatsEntity.data_type = TDEIDataType.pathways;
         downloadStatsEntity.requested_datetime = new Date().toISOString();

--- a/src/service/tdei-core-service.ts
+++ b/src/service/tdei-core-service.ts
@@ -820,6 +820,7 @@ class TdeiCoreService implements ITdeiCoreService {
             changeset_url: cloneContext.dest_changeset_upload_entity ? decodeURIComponent(cloneContext.dest_changeset_upload_entity!.remoteUrl) : undefined,
             osm_url: cloneContext.dest_osm_upload_entity ? decodeURIComponent(cloneContext.dest_osm_upload_entity!.remoteUrl) : undefined,
             latest_osm_url: cloneContext.dest_osm_upload_entity ? decodeURIComponent(cloneContext.dest_osm_upload_entity!.remoteUrl) : undefined,
+            upload_file_size_bytes: dataset_to_be_clone.upload_file_size_bytes,
         });
         // //Update the cloned dataset with new urls
         await dbClient.query(DatasetEntity.getUpdateQuery(condition, updateFields));


### PR DESCRIPTION
Fixed following issues - 

- Updated clone dataset feature to update the datasize
- Updated `osw`, `pathways` and `flex` download dataset size is zero if dataset size is not available (fallback case)