### PR TITLE
Clone file handling

### DIFF
--- a/src/service/storage-service.ts
+++ b/src/service/storage-service.ts
@@ -99,7 +99,7 @@ class StorageService {
      * @returns a promise of the file entity
      */
     async cloneFile(fileUrl: string, destinationContainerName: string, destinationFilePath: string): Promise<FileEntity | undefined> {
-        let clonedFileEntity = this.getStorageClient()?.cloneFile(decodeURIComponent(fileUrl), destinationContainerName, destinationFilePath);
+        let clonedFileEntity = this.getStorageClient()?.cloneFile(decodeURIComponent(fileUrl), destinationContainerName, decodeURI(destinationFilePath));
         return clonedFileEntity;
     }
 


### PR DESCRIPTION
- Adding missed scenario for handing the file name with spaces. Here destination name also required to be escaped to remove encoded characters. 