### PR TITLE
Fixed Issue-[1727]

### DIFF
--- a/src/utility/utility.ts
+++ b/src/utility/utility.ts
@@ -7,6 +7,8 @@ import { PermissionRequest } from "nodets-ms-core/lib/core/auth/model/permission
 import _ from "lodash";
 import { InputException } from "../exceptions/http/http-exceptions";
 import AdmZip from "adm-zip";
+import path from "path";
+
 
 export class Utility {
 
@@ -113,19 +115,32 @@ export class Utility {
     }
 
     static calculateTotalSize(files: Express.Multer.File[]): number {
-        // Calculate the total size of the files inside the uploaded ZIP
         return files.reduce((total, file) => {
-            const zip = new AdmZip(file.buffer);
-            // Get the entries of the zip file
-            const zipEntries = zip.getEntries();
             let fileSize = 0;
-            zipEntries.forEach((entry) => {
-                // Check if the entry is a file and not a directory
-                if (!entry.isDirectory) {
-                    // Add the size of the file to the total size
-                    fileSize += entry.header.size;
+            // 1. Check extension or MIME type
+            const ext = path.extname(file.originalname).toLowerCase();
+
+            // Adjust the check below to suit your needs (e.g., look for other MIME types or handle edge cases).
+            const isZip = (ext === '.zip') || (file.mimetype === 'application/zip');
+
+            if (isZip) {
+                // 2. Parse it as a ZIP
+                try {
+                    const zip = new AdmZip(file.buffer);
+                    // Sum the sizes of all actual files (not directories) within the ZIP
+                    zip.getEntries().forEach((entry) => {
+                        if (!entry.isDirectory) {
+                            fileSize += entry.header.size;
+                        }
+                    });
+                } catch (err) {
+                    // If any error occurs (not a valid ZIP, etc.), just treat it as a normal file
+                    fileSize += file.size;
                 }
-            });
+            } else {
+                // 3. Treat it as a normal file
+                fileSize += file.size;
+            }
             return total + fileSize;
         }, 0);
     }

--- a/test/unit/utility.test.ts
+++ b/test/unit/utility.test.ts
@@ -1,4 +1,7 @@
 import { QueryCriteria } from "../../src/database/dynamic-update-query";
+import { Utility } from "../../src/utility/utility"
+import AdmZip from 'adm-zip';
+import { Express } from 'express';
 
 describe('buildUpdateQuery', () => {
     it('should build an update query with set and where clauses', () => {
@@ -52,3 +55,106 @@ describe('buildUpdateQuery', () => {
         expect(() => criteria.buildUpdateQuery()).toThrow('Invalid QueryCriteria input');
     });
 });
+
+
+describe('calculateTotalSize', () => {
+    it('should return the total size of a valid ZIP file (uncompressed contents)', () => {
+        // 1. Create an in-memory ZIP with AdmZip
+        const zip = new AdmZip();
+        const content = Buffer.from('Hello World!');
+        zip.addFile('test.txt', content);
+
+        // 2. Convert the ZIP to a Buffer
+        const zipBuffer = zip.toBuffer();
+
+        // 3. Mock up an Express.Multer.File object
+        const files: Express.Multer.File[] = [
+        {
+            originalname: 'test.zip',
+            mimetype: 'application/zip',
+            buffer: zipBuffer,
+            // The "size" is the compressed size. We'll set it for completeness,
+            // but your function uses the uncompressed size from AdmZip.
+            size: zipBuffer.length,
+        } as Express.Multer.File,
+        ];
+
+        // 4. Call the function
+        const totalSize = Utility.calculateTotalSize(files);
+
+        // 5. We expect the uncompressed size (length of "Hello World!") -> 12 bytes
+        expect(totalSize).toBe(content.length);
+    })
+
+    it('should fall back to the file size when the ZIP is invalid/corrupted', () => {
+        // 1. Create a buffer that is NOT a valid ZIP
+        const badZipBuffer = Buffer.from('NOT A VALID ZIP');
+        const files: Express.Multer.File[] = [
+          {
+            originalname: 'corrupted.zip',
+            mimetype: 'application/zip',
+            buffer: badZipBuffer,
+            size: badZipBuffer.length,
+          } as Express.Multer.File,
+        ];
+    
+        // 2. Call the function
+        const totalSize = Utility.calculateTotalSize(files);
+    
+        // 3. If AdmZip throws an error, we catch it and use file.size instead
+        expect(totalSize).toBe(badZipBuffer.length);
+      });
+
+      it('should return size for a normal file (non-ZIP)', () => {
+        // 1. Create a mock text file buffer
+        const text = 'This is a normal text file';
+        const textBuffer = Buffer.from(text);
+        const files: Express.Multer.File[] = [
+          {
+            originalname: 'test.txt',
+            mimetype: 'text/plain',
+            buffer: textBuffer,
+            size: textBuffer.length,
+          } as Express.Multer.File,
+        ];
+    
+        // 2. Since it's not recognized as ZIP, the function just adds file.size
+        const totalSize = Utility.calculateTotalSize(files);
+        expect(totalSize).toBe(textBuffer.length);
+      });
+    
+      it('should handle multiple files, mixing ZIP and non-ZIP', () => {
+        // 1. Build a valid ZIP
+        const zip = new AdmZip();
+        const zipContent = Buffer.from('Zip Content');
+        zip.addFile('inside-zip.txt', zipContent);
+        const validZipBuffer = zip.toBuffer();
+    
+        // 2. Create a normal text file buffer
+        const text = 'Plain text';
+        const textBuffer = Buffer.from(text);
+    
+        // 3. Mock Multer files
+        const files: Express.Multer.File[] = [
+          {
+            originalname: 'archive.zip',
+            mimetype: 'application/zip',
+            buffer: validZipBuffer,
+            size: validZipBuffer.length,
+          } as Express.Multer.File,
+          {
+            originalname: 'file.txt',
+            mimetype: 'text/plain',
+            buffer: textBuffer,
+            size: textBuffer.length,
+          } as Express.Multer.File,
+        ];
+    
+        // 4. We expect total = uncompressed ZIP content size + text file size
+        const expectedTotal = zipContent.length + textBuffer.length;
+        const totalSize = Utility.calculateTotalSize(files);
+        expect(totalSize).toBe(expectedTotal);
+      });
+
+
+})


### PR DESCRIPTION
- Fixed Issue-[1727](https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/1727)
- Updated `calculateTotalSize` to handle the zip.
- Added logic to attempt parsing each uploaded file as a ZIP.
- If parsing fails (invalid or non-ZIP), the file is treated as a regular file and its size is used directly.
- This prevents errors like `No END header found` for non-ZIP files.
- Added unit test cases to cover, valid zip, non-zip, corrupt zip and multiple mixed fixed.


**Without Fix**
Every file was parsed as a ZIP (new AdmZip(file.buffer)), causing errors like `No END header found` when the file wasn’t actually a ZIP.

**With Fix**
We attempt to parse the file as a ZIP inside a `try/catch`. If parsing fails, we fall back to using the file’s size. This prevents errors for non-ZIP files.


**Testing Scenarios**

**Valid ZIP Test:** We create a small in-memory ZIP file containing test.txt with the content "Hello World!". The function should sum up the uncompressed size (12 bytes).
**Corrupted ZIP:** If the file’s name or MIME type says "ZIP" but the buffer is invalid, AdmZip throws an error, which we catch, causing us to default to `file.size`.
**Non-ZIP:** If the file has an extension/MIME type that isn't `.zip` or `application/zip`, we simply add file.size.
**Multiple Files:** Ensures the logic is correct when dealing with multiple files, a mix of valid ZIP and non-ZIP.