### PR TITLE
Revert core package

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "lodash": "^4.17.21",
     "multer": "1.4.5-lts.1",
     "node-fetch": "^2.6.7",
-    "nodets-ms-core": "0.0.17",
+    "nodets-ms-core": "0.0.15",
     "pg": "^8.8.0",
     "reflect-metadata": "^0.1.13",
     "supertest": "^6.3.3",

--- a/src/environment/environment.ts
+++ b/src/environment/environment.ts
@@ -18,7 +18,6 @@ export const environment = {
         confidenceResponseSubscription: process.env.CONF_RES_SUB,
         formatterSubscription: process.env.FORMATTER_SUBSCRIPTION,
         validationTopic: process.env.VALIDATION_TOPIC,
-        maxConcurrentMessages: parseInt(process.env.MAX_CONCURRENT_MESSAGES ?? "2"),
     },
     database: {
         username: process.env.POSTGRES_USER,

--- a/src/orchestrator/services/orchestrator-service.ts
+++ b/src/orchestrator/services/orchestrator-service.ts
@@ -4,7 +4,6 @@ import { QueueMessage } from "nodets-ms-core/lib/core/queue";
 import { GENERIC_WORKFLOW_IDENTIFIER, OrchestratorConfigContext, Workflow } from "../models/config-model";
 import { EventEmitter } from 'events';
 import workflowDatabaseService from "./workflow-database-service";
-import { environment } from "../../environment/environment";
 
 export interface IOrchestratorService {
     /**
@@ -104,7 +103,7 @@ export class OrchestratorService {
     private getTopicInstance(topicName: string) {
         let topic = this.topicCollection.get(topicName);
         if (!topic) {
-            topic = Core.getTopic(topicName, null, environment.eventBus.maxConcurrentMessages);
+            topic = Core.getTopic(topicName);
             this.topicCollection.set(topicName, topic);
         }
         return topic;

--- a/src/orchestrator_v2/orchestrator-service-v2.ts
+++ b/src/orchestrator_v2/orchestrator-service-v2.ts
@@ -7,7 +7,6 @@ import _ from 'lodash';
 import { Task, WorkflowContext, WorkflowStatus } from "./workflow/workflow-context.model";
 import { WorkflowDetailsEntity } from "../database/entity/workflow-details-entity";
 import { OrchestratorUtility } from "./orchestrator-utility";
-import { environment } from "../environment/environment";
 
 export interface IOrchestratorService_v2 {
     startWorkflow(job_id: string, workflowName: string, workflow_input: any, user_id: string): Promise<void>;
@@ -67,7 +66,7 @@ export class OrchestratorService_v2 implements IOrchestratorService_v2 {
     private getTopicInstance(topicName: string) {
         let topic = this.topicCollection.get(topicName);
         if (!topic) {
-            topic = Core.getTopic(topicName, null, environment.eventBus.maxConcurrentMessages);
+            topic = Core.getTopic(topicName);
             this.topicCollection.set(topicName, topic);
         }
         return topic;


### PR DESCRIPTION
## Changes Introduced
- Revert core package version from **0.0.17** to **0.0.15**.
- Reason of reverting
    - Observed an issue where multiple subscriptions were receiving messages unexpectedly.
    - Additionally, in case of a connection error, the system attempts to re-establish all connections related to subscriptions, including the **dead letter queue (DLQ)**. However, it fails to recover all subscriptions—for example, out of approximately **25 subscriptions**, 2-3 fail to recover, while the rest reconnect successfully.
- The core package will be upgraded again once this issue is fully resolved.