### PR TITLE
plus sign email issue fix

### DIFF
--- a/src/service/tdei-core-service.ts
+++ b/src/service/tdei-core-service.ts
@@ -49,7 +49,7 @@ class TdeiCoreService implements ITdeiCoreService {
      */
     async regenerateApiKey(username: string): Promise<string> {
         try {
-            const requestUrl = `${environment.regenerateApiKeyUrl}?username=${username}`;
+            const requestUrl = `${environment.regenerateApiKeyUrl}?username=${encodeURIComponent(username)}`;
 
             const result = await fetch(requestUrl as string, {
                 method: 'post'


### PR DESCRIPTION
## Bug Fix
###  DevBoard Task  
https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/1789

### Issue Summary  
- User name having with '+' sign,  when requests for user profile details , backend service gives 404 user not found. 
- Nodejs considered '+' sign as  special character and replaces with space, which is the reason system gives 404.

### Fix Implemented  
- Express request.query transforms '+' sign to space, so to avoiding the transform , we used raw query to extract the user_name and decodeURL 
- Fix can take encoded or decoded value and process both of them properly. 
- Ex . username=alex+dev@test.com or alex%2Bdev%40test.com
- Added extra check for early exit of function if no auth token. 

### Impacted Areas for Testing  
- Get user profile