### PR TITLE
task 1938

### DIFF
--- a/src/constants/app-constants.ts
+++ b/src/constants/app-constants.ts
@@ -22,3 +22,4 @@ export enum WorkflowName {
 }
 
 export const ONE_GB_IN_BYTES = 1073741824;
+export const TWO_GB_IN_BYTES = 2147483648;

--- a/src/controller/osw-controller.ts
+++ b/src/controller/osw-controller.ts
@@ -19,7 +19,7 @@ import Ajv, { ErrorObject } from "ajv";
 import polygonSchema from "../../schema/polygon.geojson.schema.json";
 import { SpatialJoinRequest, UnionRequest } from "../model/request-interfaces";
 import { apiTracker } from "../middleware/api-tracker";
-import { ONE_GB_IN_BYTES } from "../constants/app-constants";
+import { TWO_GB_IN_BYTES } from "../constants/app-constants";
 /**
   * Multer for multiple uploads
   * Configured to pull to 'uploads' folder
@@ -367,8 +367,8 @@ class OSWController implements IController {
 
             const file_size_in_bytes = Utility.calculateTotalSize([request.file] as any);
             //if file size greater than 1GB then throw error
-            if (file_size_in_bytes > ONE_GB_IN_BYTES) {
-                throw new HttpException(400, `The total size of dataset zip files exceeds 1 GB upload limit.`);
+            if (file_size_in_bytes > TWO_GB_IN_BYTES) {
+                throw new HttpException(400, `The total size of dataset zip files exceeds ${TWO_GB_IN_BYTES / (1024 * 1024 * 1024)} GB upload limit.`);
             }
 
 
@@ -491,8 +491,8 @@ class OSWController implements IController {
 
             const file_size_in_bytes = Utility.calculateTotalSize(uploadRequest.datasetFile);
             //if file size greater than 1GB then throw error
-            if (file_size_in_bytes > ONE_GB_IN_BYTES) {
-                throw new HttpException(400, `The total size of dataset zip files exceeds 1 GB upload limit.`);
+            if (file_size_in_bytes > TWO_GB_IN_BYTES) {
+                throw new HttpException(400, `The total size of dataset zip files exceeds ${TWO_GB_IN_BYTES / (1024 * 1024 * 1024)} GB upload limit.`);
             }
 
             if (!uploadRequest.metadataFile) {
@@ -578,8 +578,8 @@ class OSWController implements IController {
 
             const file_size_in_bytes = Utility.calculateTotalSize([request.file] as any);
             //if file size greater than 1GB then throw error
-            if (file_size_in_bytes > ONE_GB_IN_BYTES) {
-                throw new HttpException(400, `The total size of dataset zip files exceeds 1 GB upload limit.`);
+            if (file_size_in_bytes > TWO_GB_IN_BYTES) {
+                throw new HttpException(400, `The total size of dataset zip files exceeds ${TWO_GB_IN_BYTES / (1024 * 1024 * 1024)} GB upload limit.`);
             }
 
             let source = request.body['source_format']; //TODO: Validate the input enums 

--- a/test/unit/osw.controller.test.ts
+++ b/test/unit/osw.controller.test.ts
@@ -5,7 +5,7 @@ import HttpException from "../../src/exceptions/http/http-base-exception";
 import { ForbiddenAccess, InputException, UnAuthenticated } from "../../src/exceptions/http/http-exceptions";
 import tdeiCoreService from "../../src/service/tdei-core-service";
 import { Utility } from "../../src/utility/utility";
-import { ONE_GB_IN_BYTES } from "../../src/constants/app-constants";
+import { TWO_GB_IN_BYTES } from "../../src/constants/app-constants";
 
 // group test using describe
 describe("OSW Controller Test", () => {
@@ -509,12 +509,12 @@ describe("OSW Controller Test", () => {
         it('should handle file size restriction error', async () => {
             const req = getMockReq();
             const { res, next } = getMockRes();
-            jest.spyOn(Utility, "calculateTotalSize").mockReturnValue(ONE_GB_IN_BYTES + 1);
+            jest.spyOn(Utility, "calculateTotalSize").mockReturnValue(TWO_GB_IN_BYTES + 1);
 
             await oswController.processUploadRequest(mockRequest, mockResponse, mockNext);
 
             expect(mockResponse.status).toHaveBeenCalledWith(400);
-            expect(mockResponse.send).toHaveBeenCalledWith('The total size of dataset zip files exceeds 1 GB upload limit.');
+            expect(mockResponse.send).toHaveBeenCalledWith(`The total size of dataset zip files exceeds ${TWO_GB_IN_BYTES / (1024 * 1024 * 1024)} GB upload limit.`);
             expect(mockNext).toHaveBeenCalledWith(expect.any(HttpException));
         });
     });
@@ -636,12 +636,12 @@ describe("OSW Controller Test", () => {
         it('should handle file size restriction error', async () => {
             const req = getMockReq();
             const { res, next } = getMockRes();
-            jest.spyOn(Utility, "calculateTotalSize").mockReturnValue(ONE_GB_IN_BYTES + 1);
+            jest.spyOn(Utility, "calculateTotalSize").mockReturnValue(TWO_GB_IN_BYTES + 1);
 
             await oswController.processValidationOnlyRequest(mockRequest, mockResponse, mockNext);
 
             expect(mockResponse.status).toHaveBeenCalledWith(400);
-            expect(mockResponse.send).toHaveBeenCalledWith('The total size of dataset zip files exceeds 1 GB upload limit.');
+            expect(mockResponse.send).toHaveBeenCalledWith(`The total size of dataset zip files exceeds ${TWO_GB_IN_BYTES / (1024 * 1024 * 1024)} GB upload limit.`);
             expect(mockNext).toHaveBeenCalledWith(expect.any(HttpException));
         });
     });
@@ -776,12 +776,12 @@ describe("OSW Controller Test", () => {
         it('should handle file size restriction error', async () => {
             const req = getMockReq();
             const { res, next } = getMockRes();
-            jest.spyOn(Utility, "calculateTotalSize").mockReturnValue(ONE_GB_IN_BYTES + 1);
+            jest.spyOn(Utility, "calculateTotalSize").mockReturnValue(TWO_GB_IN_BYTES + 1);
 
             await oswController.createFormatRequest(mockRequest, mockResponse, mockNext);
 
             expect(mockResponse.status).toHaveBeenCalledWith(400);
-            expect(mockResponse.send).toHaveBeenCalledWith('The total size of dataset zip files exceeds 1 GB upload limit.');
+            expect(mockResponse.send).toHaveBeenCalledWith(`The total size of dataset zip files exceeds ${TWO_GB_IN_BYTES / (1024 * 1024 * 1024)} GB upload limit.`);
             expect(mockNext).toHaveBeenCalledWith(expect.any(HttpException));
         });
     });


### PR DESCRIPTION
## DevBoard Task  
https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/1938

## Changes Introduced  
-  Upload limit for OSW dataset operations updated from 1GB to 2GB limit. 

## Impacted Areas for Testing  
-  Test OSW upload, validate and Format with dataset less then 2GB and above 2GB to validate the limit. 

## Test Cases
- Updated 
