### PR TITLE
Added data_viewer_allowed in project_group to strict boolean in getDatasets

### DIFF
--- a/src/model/dataset-dto.ts
+++ b/src/model/dataset-dto.ts
@@ -29,6 +29,7 @@ export class DatasetDTO extends AbstractDomainEntity {
 
 export interface IProjectGroup {
     tdei_project_group_id: string;
+    data_viewer_allowed: boolean;
     name: string;
 }
 

--- a/src/model/dataset-get-query-params.ts
+++ b/src/model/dataset-get-query-params.ts
@@ -182,7 +182,7 @@ export class DatasetQueryParams {
             throw new InputException("Invalid bounding box provided." + this.bbox)
 
         //Select columns
-        const selectColumns = ['ST_AsGeoJSON(dataset_area) as dataset_area2', '*', 'pg.name as project_group_name', 's.name as service_name', 'd.name as dataset_name'];
+        const selectColumns = ['ST_AsGeoJSON(dataset_area) as dataset_area2', '*', 'pg.name as project_group_name', 'pg.data_viewer_config as data_viewer_config', 's.name as service_name', 'd.name as dataset_name'];
         //Main table name
         const mainTableName = 'content.dataset d';
         //Joins

--- a/src/service/tdei-core-service.ts
+++ b/src/service/tdei-core-service.ts
@@ -358,8 +358,11 @@ class TdeiCoreService implements ITdeiCoreService {
                 name: x.service_name,
                 tdei_service_id: x.tdei_service_id,
             };
+
+            const allowed = !!(x?.data_viewer_config?.dataset_viewer_allowed);
             osw.project_group = {
                 name: x.project_group_name,
+                data_viewer_allowed: allowed,
                 tdei_project_group_id: x.tdei_project_group_id,
             };
             if (osw.metadata.dataset_detail.dataset_area) {


### PR DESCRIPTION
## DevBoard Task  


## Changes Introduced  
-  getDatasets to always return a strict boolean for osw.project_group.data_viewer_allowed, and adds comprehensive unit tests covering truthy/falsy inputs.


## Impacted Areas for Testing  
-  TDEI Portal

