### PR TITLE
Fix project group authorization for download feedbacks endpoint

### DIFF
--- a/src/middleware/authorize-middleware.ts
+++ b/src/middleware/authorize-middleware.ts
@@ -38,6 +38,10 @@ export const authorize = (approvedRoles: string[]) => {
                 req.body.tdei_project_group_id = req.params["tdei_project_group_id"];
                 await tdeiCoreService.checkProjectGroupExistsById(req.params["tdei_project_group_id"])
             }
+            else if (req.query["tdei_project_group_id"]) {
+                req.body.tdei_project_group_id = req.query["tdei_project_group_id"] as string;
+                await tdeiCoreService.checkProjectGroupExistsById(req.body.tdei_project_group_id);
+            }
             else if (req.params["tdei_dataset_id"]) {
                 //Fetch tdei_project_group_id from tdei_dataset_id
                 let osw = await tdeiCoreService.getDatasetDetailsById(req.params["tdei_dataset_id"]);

--- a/src/service/interface/osw-service-interface.ts
+++ b/src/service/interface/osw-service-interface.ts
@@ -7,6 +7,7 @@ import { SpatialJoinRequest, UnionRequest } from "../../model/request-interfaces
 import { FeedbackRequestDto, FeedbackResponseDTO } from "../../model/feedback-dto";
 import { feedbackRequestParams } from "../../model/feedback-request-params";
 import { FeedbackMetadataDTO } from "../../model/feedback-metadata-dto";
+import { Readable } from "stream";
 
 export interface IOswService {
     /**
@@ -50,6 +51,13 @@ export interface IOswService {
      * @returns A Promise that resolves to an array of feedback DTOs.
      */
     getFeedbacks(user_id: any, params: feedbackRequestParams): Promise<Array<FeedbackResponseDTO>>;
+
+    /**
+     * Streams feedbacks for a project group as CSV.
+     * @param tdei_project_group_id - The project group identifier.
+     * @returns A Readable stream containing the CSV data.
+     */
+    downloadFeedbacks(tdei_project_group_id: string): Promise<Readable>;
     /**
      * Adds a feedback request.
      * @param feedback - The feedback data transfer object.

--- a/test/unit/middleware/authorize-middleware.test.ts
+++ b/test/unit/middleware/authorize-middleware.test.ts
@@ -56,6 +56,22 @@ describe('Authorize Middleware', () => {
         expect(next).toHaveBeenCalledWith();
     });
 
+    it('should set tdei_project_group_id from query if params are missing', async () => {
+        const req = getMockReq({ query: { tdei_project_group_id: 'someProjectGroupId' } });
+        const { res, next } = getMockRes();
+        req.headers.authorization = 'Bearer validToken';
+        req.body.user_id = 'someUserId';
+
+        const mockedOSW: any = { tdei_project_group_id: 'someProjectGroupId' };
+        jest.spyOn(tdeiCoreService, "checkProjectGroupExistsById").mockResolvedValueOnce(mockedOSW);
+        mockCoreAuth(true);
+
+        await authorize(['approvedRole1', 'approvedRole2'])(req, res, next);
+
+        expect(req.body.tdei_project_group_id).toEqual('someProjectGroupId');
+        expect(next).toHaveBeenCalledWith();
+    });
+
     it('should call next() with forbidden error if roles are not approved', async () => {
         const req = getMockReq()
         const { res, next } = getMockRes();


### PR DESCRIPTION
## Summary
- allow authorize middleware to read `tdei_project_group_id` from query strings
- cover query-string extraction in authorize middleware tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1847cef0483278d51c4726ef925da