### PR TITLE
Support case-insensitive feedback download formats

### DIFF
--- a/src/model/feedback-download-request-params.ts
+++ b/src/model/feedback-download-request-params.ts
@@ -24,6 +24,9 @@ export class FeedbackDownloadRequestParams extends feedbackRequestParams {
     constructor(init?: Partial<FeedbackDownloadRequestParams>) {
         super();
         Object.assign(this, init);
+        if (this.format) {
+            this.format = this.format.toLowerCase();
+        }
         if (init?.page_no === undefined) this.page_no = undefined;
         if (init?.page_size === undefined) this.page_size = undefined;
         if (init?.due_date !== undefined && init?.sort_by === undefined) {

--- a/test/unit/osw.service.test.ts
+++ b/test/unit/osw.service.test.ts
@@ -1173,7 +1173,7 @@ describe("OSW Service Test", () => {
         afterEach(() => {
             jest.restoreAllMocks();
         });
-        test("should return csv stream of feedbacks without limit", async () => {
+        test.each(['csv', 'CSV'])("should return csv stream of feedbacks without limit for format %s", async (fmt) => {
             const rows = [{
                 id: 1,
                 tdei_project_group_id: 'pg1',
@@ -1191,7 +1191,7 @@ describe("OSW Service Test", () => {
                 due_date: new Date('2025-01-02T00:00:00Z')
             }];
             jest.spyOn(dbClient, 'query').mockResolvedValueOnce(<any>{ rows });
-            const params = new FeedbackDownloadRequestParams({ tdei_project_group_id: 'pg1' });
+            const params = new FeedbackDownloadRequestParams({ tdei_project_group_id: 'pg1', format: fmt });
 
             const stream = await oswService.downloadFeedbacks(params);
             const chunks: Buffer[] = [];
@@ -1207,7 +1207,7 @@ describe("OSW Service Test", () => {
             expect(query.text).not.toContain('LIMIT');
         });
 
-        test("should return geojson stream of feedbacks", async () => {
+        test.each(['geojson', 'geoJSON', 'GeoJSON', 'GEOJSON'])("should return geojson stream of feedbacks for format %s", async (fmt) => {
             const rows = [{
                 id: 1,
                 tdei_project_group_id: 'pg1',
@@ -1225,7 +1225,7 @@ describe("OSW Service Test", () => {
                 due_date: new Date('2025-01-02T00:00:00Z')
             }];
             jest.spyOn(dbClient, 'query').mockResolvedValueOnce(<any>{ rows });
-            const params = new FeedbackDownloadRequestParams({ tdei_project_group_id: 'pg1', format: 'geojson' });
+            const params = new FeedbackDownloadRequestParams({ tdei_project_group_id: 'pg1', format: fmt });
 
             const stream = await oswService.downloadFeedbacks(params);
             const chunks: Buffer[] = [];


### PR DESCRIPTION
## Summary
- Normalize feedback download format input to allow any casing
- Add unit tests for csv/CSV and geojson variants in controller and service

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b67f0e206c8327851ad95d286ba44e